### PR TITLE
Fix integration when instrumentation is not present

### DIFF
--- a/dist/lib/integrations/http.js
+++ b/dist/lib/integrations/http.js
@@ -63,7 +63,7 @@ class HttpIntegration extends integrations_1.RequireIntegration {
             // Start a scout instrumentation and pull out the stopSpan
             const opName = `HTTP/${method.toUpperCase()}`;
             // Start an asynchronous instrumentation and pull particulars from it
-            let stopSpan;
+            let stopSpan = () => undefined;
             let reqSpan;
             integration.scout.instrument(opName, (stop, { span }) => {
                 stopSpan = stop;

--- a/lib/integrations/http.ts
+++ b/lib/integrations/http.ts
@@ -70,7 +70,7 @@ export class HttpIntegration extends RequireIntegration {
             const opName = `HTTP/${method.toUpperCase()}`;
 
             // Start an asynchronous instrumentation and pull particulars from it
-            let stopSpan: () => void;
+            let stopSpan: () => void = () => undefined;
             let reqSpan: ScoutSpan;
 
             integration.scout.instrument(opName, (stop, {span}) => {


### PR DESCRIPTION
This hotfix ensures the `http` (request) integration works even when the instrumentation is not present (on platforms like windows).

This should be released with version `0.1.9-rc.1`