### PR TITLE
200 investigate nuxt failure

### DIFF
--- a/dist/lib/agents/external-process.js
+++ b/dist/lib/agents/external-process.js
@@ -410,6 +410,7 @@ class ExternalProcessAgent extends events_1.EventEmitter {
                 .fromBinary(framedData)
                 .then(msg => {
                 this.emit(types_1.AgentEvent.SocketResponseReceived, msg, socket);
+                this.logFn(`[scout/external-process] Received & parsed response of type:\n ${msg.type}`, types_1.LogLevel.Debug);
                 switch (msg.type) {
                     case types_1.AgentResponseType.V1StartRequest:
                         this.emit(types_1.AgentEvent.RequestStarted);

--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -28,6 +28,7 @@ setupRequireIntegrations([
     "ejs",
     // Web frameworks
     "express",
+    "nuxt",
     // NodeJS internals
     "http",
 ]);

--- a/dist/lib/integrations/index.js
+++ b/dist/lib/integrations/index.js
@@ -8,6 +8,7 @@ const mustache_1 = require("./mustache");
 const ejs_1 = require("./ejs");
 const http_1 = require("./http");
 const express_1 = require("./express");
+const nuxt_1 = require("./nuxt");
 const integrations_1 = require("../types/integrations");
 function getIntegrationForPackage(pkg) {
     switch (pkg) {
@@ -19,6 +20,7 @@ function getIntegrationForPackage(pkg) {
         case ejs_1.default.getPackageName(): return ejs_1.default;
         case http_1.default.getPackageName(): return http_1.default;
         case express_1.default.getPackageName(): return express_1.default;
+        case nuxt_1.default.getPackageName(): return nuxt_1.default;
         default: return integrations_1.doNothingRequireIntegration;
     }
 }

--- a/dist/lib/integrations/nuxt.d.ts
+++ b/dist/lib/integrations/nuxt.d.ts
@@ -1,0 +1,13 @@
+import { RequireIntegration } from "../types/integrations";
+export declare class NuxtIntegration extends RequireIntegration {
+    protected readonly packageName: string;
+    protected shim(nuxtExport: any): any;
+    /**
+     * Shim for nuxt's `Nuxt` constructor
+     *
+     * @param {any} nuxtExport - nuxt's export
+     */
+    private shimNuxtCtor;
+}
+declare const _default: NuxtIntegration;
+export default _default;

--- a/dist/lib/integrations/nuxt.js
+++ b/dist/lib/integrations/nuxt.js
@@ -1,0 +1,80 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const integrations_1 = require("../types/integrations");
+const types_1 = require("../types");
+// Hook into the express and mongodb module
+class NuxtIntegration extends integrations_1.RequireIntegration {
+    constructor() {
+        super(...arguments);
+        this.packageName = "nuxt";
+    }
+    shim(nuxtExport) {
+        nuxtExport = this.shimNuxtCtor(nuxtExport);
+        return nuxtExport;
+    }
+    /**
+     * Shim for nuxt's `Nuxt` constructor
+     *
+     * @param {any} nuxtExport - nuxt's export
+     */
+    shimNuxtCtor(nuxtExport) {
+        const OriginalCtor = nuxtExport.Nuxt;
+        const integration = this;
+        // Create a constructor identical to the original Nuxt constructor
+        const Nuxt = function Nuxt() {
+            const originalArgs = arguments;
+            integration.logFn("[scout/integrations/nuxt] Creating Nuxt object...", types_1.LogLevel.Debug);
+            // Create the instance
+            const instance = new OriginalCtor(...originalArgs);
+            // We need to shim nuxt.render such that when it is called
+            const originalRender = instance.render;
+            instance.render = function render(req, res, next) {
+                // If no scout instance is available then run the function normally
+                if (!integration.scout) {
+                    return originalRender.apply(this, arguments);
+                }
+                // If we have context set up (we are in an async context and can obtain the current request)
+                if (integration.scout.getCurrentRequest()) {
+                    integration.logFn("[scout/integrations/nuxt] ScoutRequest present while serving [${req.url}]", types_1.LogLevel.Debug);
+                    return originalRender.apply(this, arguments);
+                }
+                // At this point, if a scout instance and there is no current scout request
+                // that means any activity nuxt triggers (ex. HTTP requests with 'net')
+                // are going to happen *without* a containg request/controller span this
+                // happens because requests to Nuxt do *not* flow throw the normal
+                // middleware flow of express/other integrations
+                const url = req.url || "<unknown>";
+                const method = req.method || "<unknown>";
+                const controllerName = `Controller/${method.toUpperCase()} ${url}`;
+                // Start a transaction that finished when res.end is called
+                return integration.scout.transaction(controllerName, finishTransaction => {
+                    // Ensure the integration and instrument functions are stil present by the time we run
+                    if (!integration.scout || !integration.scout.instrument) {
+                        integration.logFn("[scout/integrations/nuxt] Integration broken or missing instrument function", types_1.LogLevel.Warn);
+                        finishTransaction();
+                        return originalRender.apply(this, [req, res, next]);
+                    }
+                    // Perform the instrumentation
+                    return integration.scout.instrument(controllerName, () => {
+                        // No need to finish the span explicitly since transaction finish will close interior spans
+                        const originalResEnd = res.end;
+                        res.end = function () {
+                            finishTransaction();
+                            return originalResEnd.apply(this, arguments);
+                        };
+                        return originalRender.apply(this, [req, res, next]);
+                    });
+                });
+            };
+            return instance;
+        };
+        // NOTE: we have to shim nuxt this way because the objects in it do *not* have setters
+        const rebuiltNuxtExport = { Nuxt };
+        Object.keys(nuxtExport)
+            .filter(k => k !== "Nuxt")
+            .forEach(k => rebuiltNuxtExport[k] = nuxtExport[k]);
+        return rebuiltNuxtExport;
+    }
+}
+exports.NuxtIntegration = NuxtIntegration;
+exports.default = new NuxtIntegration();

--- a/lib/agents/external-process.ts
+++ b/lib/agents/external-process.ts
@@ -506,6 +506,11 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
                     .then(msg => {
                         this.emit(AgentEvent.SocketResponseReceived, msg, socket);
 
+                        this.logFn(
+                            `[scout/external-process] Received & parsed response of type:\n ${msg.type}`,
+                            LogLevel.Debug,
+                        );
+
                         switch (msg.type) {
                             case AgentResponseType.V1StartRequest:
                                 this.emit(AgentEvent.RequestStarted);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -35,6 +35,7 @@ setupRequireIntegrations([
 
     // Web frameworks
     "express",
+    "nuxt",
 
     // NodeJS internals
     "http",

--- a/lib/integrations/index.ts
+++ b/lib/integrations/index.ts
@@ -6,6 +6,7 @@ import mustacheIntegration from "./mustache";
 import ejsIntegration from "./ejs";
 import httpIntegration from "./http";
 import expressIntegration from "./express";
+import nuxtIntegration from "./nuxt";
 import { doNothingRequireIntegration, RequireIntegration } from "../types/integrations";
 
 export function getIntegrationForPackage(pkg: string): RequireIntegration {
@@ -18,6 +19,7 @@ export function getIntegrationForPackage(pkg: string): RequireIntegration {
         case ejsIntegration.getPackageName(): return ejsIntegration;
         case httpIntegration.getPackageName(): return httpIntegration;
         case expressIntegration.getPackageName(): return expressIntegration;
+        case nuxtIntegration.getPackageName(): return nuxtIntegration;
         default: return doNothingRequireIntegration;
     }
 }

--- a/lib/integrations/nuxt.ts
+++ b/lib/integrations/nuxt.ts
@@ -1,0 +1,98 @@
+import * as path from "path";
+import { ExportBag, RequireIntegration } from "../types/integrations";
+import { Scout } from "../scout";
+import { LogFn, LogLevel, ScoutContextName, ScoutSpanOperation } from "../types";
+import * as Constants from "../constants";
+
+// Hook into the express and mongodb module
+export class NuxtIntegration extends RequireIntegration {
+    protected readonly packageName: string = "nuxt";
+
+    protected shim(nuxtExport: any): any {
+        nuxtExport = this.shimNuxtCtor(nuxtExport);
+
+        return nuxtExport;
+    }
+
+    /**
+     * Shim for nuxt's `Nuxt` constructor
+     *
+     * @param {any} nuxtExport - nuxt's export
+     */
+    private shimNuxtCtor(nuxtExport: any): any {
+        const OriginalCtor = nuxtExport.Nuxt;
+        const integration = this;
+
+        // Create a constructor identical to the original Nuxt constructor
+        const Nuxt = function Nuxt() {
+            const originalArgs = arguments;
+            integration.logFn("[scout/integrations/nuxt] Creating Nuxt object...", LogLevel.Debug);
+
+            // Create the instance
+            const instance = new OriginalCtor(...originalArgs);
+
+            // We need to shim nuxt.render such that when it is called
+            const originalRender = instance.render;
+            instance.render = function render(req, res, next) {
+                // If no scout instance is available then run the function normally
+                if (!integration.scout) { return originalRender.apply(this, arguments); }
+
+                // If we have context set up (we are in an async context and can obtain the current request)
+                if (integration.scout.getCurrentRequest()) {
+                    integration.logFn(
+                        "[scout/integrations/nuxt] ScoutRequest present while serving [${req.url}]",
+                        LogLevel.Debug,
+                    );
+                    return originalRender.apply(this, arguments);
+                }
+
+                // At this point, if a scout instance and there is no current scout request
+                // that means any activity nuxt triggers (ex. HTTP requests with 'net')
+                // are going to happen *without* a containg request/controller span this
+                // happens because requests to Nuxt do *not* flow throw the normal
+                // middleware flow of express/other integrations
+
+                const url = req.url || "<unknown>";
+                const method = req.method || "<unknown>";
+                const controllerName = `Controller/${method.toUpperCase()} ${url}`;
+
+                // Start a transaction that finished when res.end is called
+                return integration.scout.transaction(controllerName, finishTransaction => {
+                    // Ensure the integration and instrument functions are stil present by the time we run
+                    if (!integration.scout || !integration.scout.instrument) {
+                        integration.logFn(
+                            "[scout/integrations/nuxt] Integration broken or missing instrument function",
+                            LogLevel.Warn,
+                        );
+                        finishTransaction();
+                        return originalRender.apply(this, [req, res, next]);
+                    }
+
+                    // Perform the instrumentation
+                    return integration.scout.instrument(controllerName, () => {
+                        // No need to finish the span explicitly since transaction finish will close interior spans
+                        const originalResEnd = res.end;
+                        res.end = function() {
+                            finishTransaction();
+                            return originalResEnd.apply(this, arguments);
+                        };
+
+                        return originalRender.apply(this, [req, res, next]);
+                    });
+                });
+            };
+
+            return instance;
+        };
+
+        // NOTE: we have to shim nuxt this way because the objects in it do *not* have setters
+        const rebuiltNuxtExport = {Nuxt};
+        Object.keys(nuxtExport)
+            .filter(k => k !== "Nuxt")
+            .forEach(k => rebuiltNuxtExport[k] = nuxtExport[k]);
+
+        return rebuiltNuxtExport;
+    }
+}
+
+export default new NuxtIntegration();


### PR DESCRIPTION
Resolves #200

This adds preliminary support for `nuxt` w/ `express` servers -- particularly the endpoints that are hit that do not touch express (but only touch the `nuxt` connect-powered server)