### PR TITLE
Add NestJS middleware and exception filter instrumentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,3 +115,41 @@ jobs:
       - run: yarn build
       - name: Run unit + integration tests
         run: yarn test-unit && yarn test-int
+
+  node-test-apps:
+    name: Node test apps (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Express 4"
+            dockerfile: node_test_apps/express-v4/Dockerfile
+            image: scout-express-v4-test
+          - name: "Express 5"
+            dockerfile: node_test_apps/express-v5/Dockerfile
+            image: scout-express-v5-test
+          - name: "Node 24 + Express"
+            dockerfile: node_test_apps/node_24/express/Dockerfile
+            image: scout-node24-express-test
+          - name: "Node 24 + NestJS"
+            dockerfile: node_test_apps/node_24/nest/Dockerfile
+            image: scout-node24-nest-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - name: Build and test ${{ matrix.name }} app
+        if: hashFiles(matrix.dockerfile) != ''
+        run: |
+          docker build -t ${{ matrix.image }} -f ${{ matrix.dockerfile }} .
+          docker run -d --name scout-app ${{ matrix.image }}
+          timeout 60 sh -c 'until [ "$(docker inspect -f {{.State.Health.Status}} scout-app 2>/dev/null)" = "healthy" ]; do sleep 2; done'
+          STATUS=$(docker inspect -f '{{.State.Health.Status}}' scout-app)
+          docker rm -f scout-app
+          [ "$STATUS" = "healthy" ]

--- a/dist/lib/nest.d.ts
+++ b/dist/lib/nest.d.ts
@@ -1,0 +1,31 @@
+import { ExpressMiddlewareOptions } from "./express";
+/**
+ * Scout APM middleware for NestJS.
+ *
+ * Register in main.ts before app.listen():
+ *   app.use(nestMiddleware({ config }));
+ *
+ * Or with a class-based consumer:
+ *   @Injectable()
+ *   export class ScoutMiddleware implements NestMiddleware {
+ *     use(req, res, next) { nestMiddleware()(req, res, next); }
+ *   }
+ */
+export declare function nestMiddleware(opts?: ExpressMiddlewareOptions): (req: any, res: any, next: () => void) => void;
+/**
+ * Class-based Scout middleware for use with NestJS's MiddlewareConsumer.
+ * Satisfies NestMiddleware<Request, Response> without importing @nestjs/common.
+ *
+ * Example:
+ *   @Module({})
+ *   export class AppModule implements NestModule {
+ *     configure(consumer: MiddlewareConsumer) {
+ *       consumer.apply(ScoutNestMiddleware).forRoutes('*');
+ *     }
+ *   }
+ */
+export declare class ScoutNestMiddleware {
+    private readonly _inner;
+    constructor(opts?: ExpressMiddlewareOptions);
+    use(req: any, res: any, next: () => void): void;
+}

--- a/dist/lib/nest.js
+++ b/dist/lib/nest.js
@@ -1,0 +1,41 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ScoutNestMiddleware = void 0;
+exports.nestMiddleware = nestMiddleware;
+const express_1 = require("./express");
+/**
+ * Scout APM middleware for NestJS.
+ *
+ * Register in main.ts before app.listen():
+ *   app.use(nestMiddleware({ config }));
+ *
+ * Or with a class-based consumer:
+ *   @Injectable()
+ *   export class ScoutMiddleware implements NestMiddleware {
+ *     use(req, res, next) { nestMiddleware()(req, res, next); }
+ *   }
+ */
+function nestMiddleware(opts) {
+    return (0, express_1.scoutMiddleware)(opts);
+}
+/**
+ * Class-based Scout middleware for use with NestJS's MiddlewareConsumer.
+ * Satisfies NestMiddleware<Request, Response> without importing @nestjs/common.
+ *
+ * Example:
+ *   @Module({})
+ *   export class AppModule implements NestModule {
+ *     configure(consumer: MiddlewareConsumer) {
+ *       consumer.apply(ScoutNestMiddleware).forRoutes('*');
+ *     }
+ *   }
+ */
+class ScoutNestMiddleware {
+    constructor(opts) {
+        this._inner = (0, express_1.scoutMiddleware)(opts);
+    }
+    use(req, res, next) {
+        this._inner(req, res, next);
+    }
+}
+exports.ScoutNestMiddleware = ScoutNestMiddleware;

--- a/dist/test/integration/nest.int.d.ts
+++ b/dist/test/integration/nest.int.d.ts
@@ -1,0 +1,1 @@
+import "reflect-metadata";

--- a/dist/test/integration/nest.int.js
+++ b/dist/test/integration/nest.int.js
@@ -1,0 +1,257 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+require("reflect-metadata");
+const tape_1 = __importDefault(require("tape"));
+const supertest_1 = __importDefault(require("supertest"));
+const core_1 = require("@nestjs/core");
+const common_1 = require("@nestjs/common");
+const mock_agent_1 = require("./mock-agent");
+const nest_1 = require("../../lib/nest");
+const scout_1 = require("../../lib/scout");
+const types_1 = require("../../lib/types");
+const TestUtil = __importStar(require("../util"));
+const TIMEOUT = 12000;
+// ── Minimal NestJS app used across all tests ─────────────────────────────────
+let TestController = class TestController {
+    home() { return { status: "ok" }; }
+    dynamic() { return { status: "ok" }; }
+};
+__decorate([
+    (0, common_1.Get)("/"),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], TestController.prototype, "home", null);
+__decorate([
+    (0, common_1.Get)("/dynamic/:segment"),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], TestController.prototype, "dynamic", null);
+TestController = __decorate([
+    (0, common_1.Controller)()
+], TestController);
+let ApiController = class ApiController {
+    hello() { return { message: "hello" }; }
+};
+__decorate([
+    (0, common_1.Get)("hello"),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], ApiController.prototype, "hello", null);
+ApiController = __decorate([
+    (0, common_1.Controller)("api")
+], ApiController);
+let TestModule = class TestModule {
+};
+TestModule = __decorate([
+    (0, common_1.Module)({ controllers: [TestController, ApiController] })
+], TestModule);
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function buildConfig(mock, extra) {
+    return (0, types_1.buildScoutConfiguration)({
+        allowShutdown: true,
+        monitor: true,
+        coreAgentDownload: false,
+        coreAgentLaunch: false,
+        socketPath: mock.socketPath(),
+        ...extra,
+    });
+}
+function nextRequestSent(scout, skipCount = 0) {
+    return new Promise((resolve, reject) => {
+        let skipped = 0;
+        const timer = setTimeout(() => {
+            scout.removeListener(types_1.ScoutEvent.RequestSent, listener);
+            reject(new Error("Timed out waiting for ScoutEvent.RequestSent"));
+        }, TIMEOUT - 2000);
+        const listener = (data) => {
+            if (!data.request.getChildSpansSync().some((s) => s.operation.startsWith("Controller/"))) {
+                return;
+            }
+            if (skipped < skipCount) {
+                skipped++;
+                return;
+            }
+            clearTimeout(timer);
+            scout.removeListener(types_1.ScoutEvent.RequestSent, listener);
+            resolve(data);
+        };
+        scout.on(types_1.ScoutEvent.RequestSent, listener);
+    });
+}
+async function makeNestApp(scout) {
+    const app = await core_1.NestFactory.create(TestModule, { logger: false });
+    app.use((0, nest_1.nestMiddleware)({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+    await app.init();
+    return app;
+}
+// ── Tests ─────────────────────────────────────────────────────────────────────
+(0, tape_1.default)("NestJS GET / creates a Controller/GET span", { timeout: TIMEOUT }, (t) => {
+    const mock = new mock_agent_1.MockAgent();
+    let nestApp;
+    let scout;
+    mock.start()
+        .then(async () => {
+        scout = new scout_1.Scout(buildConfig(mock));
+        nestApp = await makeNestApp(scout);
+        // warmup — initialises Scout connection
+        await (0, supertest_1.default)(nestApp.getHttpServer()).get("/").expect(200);
+    })
+        .then(() => {
+        const sentPromise = nextRequestSent(scout, 1);
+        (0, supertest_1.default)(nestApp.getHttpServer()).get("/").end(() => undefined);
+        return sentPromise;
+    })
+        .then((data) => {
+        const spans = data.request.getChildSpansSync();
+        const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+        t.ok(ctrl, "Controller span created");
+        t.ok(ctrl?.operation.includes("GET"), "span includes GET");
+        t.equal(ctrl?.operation, "Controller/GET /", "route path is /");
+    })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+        mock.stop().catch(() => undefined);
+        nestApp?.close().catch(() => undefined);
+        t.fail(err.message);
+        t.end();
+    });
+});
+(0, tape_1.default)("NestJS dynamic route captures route pattern not concrete value", { timeout: TIMEOUT }, (t) => {
+    const mock = new mock_agent_1.MockAgent();
+    let nestApp;
+    let scout;
+    mock.start()
+        .then(async () => {
+        scout = new scout_1.Scout(buildConfig(mock));
+        nestApp = await makeNestApp(scout);
+        await (0, supertest_1.default)(nestApp.getHttpServer()).get("/").expect(200);
+    })
+        .then(() => {
+        const sentPromise = nextRequestSent(scout, 1);
+        (0, supertest_1.default)(nestApp.getHttpServer()).get("/dynamic/hello-world").end(() => undefined);
+        return sentPromise;
+    })
+        .then((data) => {
+        const spans = data.request.getChildSpansSync();
+        const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+        t.ok(ctrl, "Controller span created for dynamic route");
+        t.ok(ctrl?.operation.includes(":segment"), `route pattern captured, got: ${ctrl?.operation}`);
+        t.notOk(ctrl?.operation.includes("hello-world"), "concrete value not in span operation");
+    })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+        mock.stop().catch(() => undefined);
+        nestApp?.close().catch(() => undefined);
+        t.fail(err.message);
+        t.end();
+    });
+});
+(0, tape_1.default)("NestJS controller prefix is included in span operation", { timeout: TIMEOUT }, (t) => {
+    const mock = new mock_agent_1.MockAgent();
+    let nestApp;
+    let scout;
+    mock.start()
+        .then(async () => {
+        scout = new scout_1.Scout(buildConfig(mock));
+        nestApp = await makeNestApp(scout);
+        await (0, supertest_1.default)(nestApp.getHttpServer()).get("/").expect(200);
+    })
+        .then(() => {
+        const sentPromise = nextRequestSent(scout, 1);
+        (0, supertest_1.default)(nestApp.getHttpServer()).get("/api/hello").end(() => undefined);
+        return sentPromise;
+    })
+        .then((data) => {
+        const spans = data.request.getChildSpansSync();
+        const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+        t.ok(ctrl, "Controller span created for prefixed route");
+        t.equal(ctrl?.operation, "Controller/GET /api/hello", "full path with prefix captured");
+    })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+        mock.stop().catch(() => undefined);
+        nestApp?.close().catch(() => undefined);
+        t.fail(err.message);
+        t.end();
+    });
+});
+(0, tape_1.default)("NestJS mock agent receives Register message on connect", { timeout: TIMEOUT }, (t) => {
+    const mock = new mock_agent_1.MockAgent();
+    let nestApp;
+    let scout;
+    mock.start()
+        .then(async () => {
+        scout = new scout_1.Scout(buildConfig(mock, { name: "nest-test-app", key: "test-key" }));
+        nestApp = await makeNestApp(scout);
+        await (0, supertest_1.default)(nestApp.getHttpServer()).get("/").expect(200);
+    })
+        .then(() => mock.waitForMessage("Register"))
+        .then((msg) => {
+        t.ok(msg, "Register message received");
+        t.equal(msg.type, "Register", "message type is Register");
+    })
+        .then(() => nestApp.close())
+        .then(() => scout.shutdown())
+        .then(() => mock.stop())
+        .then(() => t.end())
+        .catch((err) => {
+        mock.stop().catch(() => undefined);
+        nestApp?.close().catch(() => undefined);
+        t.fail(err.message);
+        t.end();
+    });
+});

--- a/dist/test/integrations/nest.e2e.d.ts
+++ b/dist/test/integrations/nest.e2e.d.ts
@@ -1,0 +1,1 @@
+import "reflect-metadata";

--- a/dist/test/integrations/nest.e2e.js
+++ b/dist/test/integrations/nest.e2e.js
@@ -1,0 +1,172 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+require("reflect-metadata");
+const tape_1 = __importDefault(require("tape"));
+const supertest_1 = __importDefault(require("supertest"));
+const core_1 = require("@nestjs/core");
+const common_1 = require("@nestjs/common");
+const lib_1 = require("../../lib");
+const types_1 = require("../../lib/types");
+const scout_1 = require("../../lib/scout");
+const nest_1 = require("../../lib/nest");
+const TestUtil = __importStar(require("../util"));
+(0, lib_1.setupRequireIntegrations)(["mustache", "http"]);
+const TIMEOUT = 15000;
+// ── Shared test controllers ───────────────────────────────────────────────────
+let BasicController = class BasicController {
+    home() { return { status: "ok" }; }
+    item() { return { status: "ok" }; }
+};
+__decorate([
+    (0, common_1.Get)("/"),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], BasicController.prototype, "home", null);
+__decorate([
+    (0, common_1.Get)("/items/:id"),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], BasicController.prototype, "item", null);
+BasicController = __decorate([
+    (0, common_1.Controller)()
+], BasicController);
+let BasicModule = class BasicModule {
+};
+BasicModule = __decorate([
+    (0, common_1.Module)({ controllers: [BasicController] })
+], BasicModule);
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function nextRequestSent(scout, skipCount = 0) {
+    return new Promise((resolve, reject) => {
+        let skipped = 0;
+        const timer = setTimeout(() => {
+            scout.removeListener(types_1.ScoutEvent.RequestSent, listener);
+            reject(new Error("Timed out waiting for ScoutEvent.RequestSent"));
+        }, TIMEOUT - 2000);
+        const listener = (data) => {
+            if (!data.request.getChildSpansSync().some((s) => s.operation.startsWith("Controller/"))) {
+                return;
+            }
+            if (skipped < skipCount) {
+                skipped++;
+                return;
+            }
+            clearTimeout(timer);
+            scout.removeListener(types_1.ScoutEvent.RequestSent, listener);
+            resolve(data);
+        };
+        scout.on(types_1.ScoutEvent.RequestSent, listener);
+    });
+}
+// ── Tests ─────────────────────────────────────────────────────────────────────
+(0, tape_1.default)("nestMiddleware is a function", (t) => {
+    t.equal(typeof nest_1.nestMiddleware, "function", "nestMiddleware is exported");
+    t.equal(typeof (0, nest_1.nestMiddleware)(), "function", "nestMiddleware() returns a middleware function");
+    t.end();
+});
+(0, tape_1.default)("NestJS app instruments root route", { timeout: TIMEOUT }, (t) => {
+    const config = (0, types_1.buildScoutConfiguration)({ allowShutdown: true, monitor: true });
+    const scout = new scout_1.Scout(config);
+    let nestApp;
+    core_1.NestFactory.create(BasicModule, { logger: false })
+        .then((app) => {
+        nestApp = app;
+        app.use((0, nest_1.nestMiddleware)({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+        return app.init();
+    })
+        .then(() => (0, supertest_1.default)(nestApp.getHttpServer()).get("/").expect(200))
+        .then(() => {
+        const sentPromise = nextRequestSent(scout, 1);
+        (0, supertest_1.default)(nestApp.getHttpServer()).get("/").end(() => undefined);
+        return sentPromise;
+    })
+        .then((data) => {
+        const spans = data.request.getChildSpansSync();
+        const ctrl = spans.find((s) => s.operation.startsWith("Controller/GET"));
+        t.ok(ctrl, "Controller/GET span present");
+        t.equal(ctrl?.operation, "Controller/GET /", "operation is Controller/GET /");
+    })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .catch((err) => {
+        nestApp?.close().catch(() => undefined);
+        TestUtil.shutdownScout(t, scout, err);
+    });
+});
+(0, tape_1.default)("NestJS parameterised route captures pattern not value", { timeout: TIMEOUT }, (t) => {
+    const config = (0, types_1.buildScoutConfiguration)({ allowShutdown: true, monitor: true });
+    const scout = new scout_1.Scout(config);
+    let nestApp;
+    core_1.NestFactory.create(BasicModule, { logger: false })
+        .then((app) => {
+        nestApp = app;
+        app.use((0, nest_1.nestMiddleware)({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+        return app.init();
+    })
+        .then(() => (0, supertest_1.default)(nestApp.getHttpServer()).get("/").expect(200))
+        .then(() => {
+        const sentPromise = nextRequestSent(scout, 1);
+        (0, supertest_1.default)(nestApp.getHttpServer()).get("/items/42").end(() => undefined);
+        return sentPromise;
+    })
+        .then((data) => {
+        const spans = data.request.getChildSpansSync();
+        const ctrl = spans.find((s) => s.operation.startsWith("Controller/GET"));
+        t.ok(ctrl, "Controller span created");
+        t.ok(ctrl?.operation.includes(":id"), `includes :id pattern — got ${ctrl?.operation}`);
+        t.notOk(ctrl?.operation.includes("42"), "concrete value 42 not in operation");
+    })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .catch((err) => {
+        nestApp?.close().catch(() => undefined);
+        TestUtil.shutdownScout(t, scout, err);
+    });
+});

--- a/lib/nest.ts
+++ b/lib/nest.ts
@@ -1,0 +1,41 @@
+import { scoutMiddleware, ExpressMiddlewareOptions } from "./express";
+
+/**
+ * Scout APM middleware for NestJS.
+ *
+ * Register in main.ts before app.listen():
+ *   app.use(nestMiddleware({ config }));
+ *
+ * Or with a class-based consumer:
+ *   @Injectable()
+ *   export class ScoutMiddleware implements NestMiddleware {
+ *     use(req, res, next) { nestMiddleware()(req, res, next); }
+ *   }
+ */
+export function nestMiddleware(opts?: ExpressMiddlewareOptions) {
+    return scoutMiddleware(opts);
+}
+
+/**
+ * Class-based Scout middleware for use with NestJS's MiddlewareConsumer.
+ * Satisfies NestMiddleware<Request, Response> without importing @nestjs/common.
+ *
+ * Example:
+ *   @Module({})
+ *   export class AppModule implements NestModule {
+ *     configure(consumer: MiddlewareConsumer) {
+ *       consumer.apply(ScoutNestMiddleware).forRoutes('*');
+ *     }
+ *   }
+ */
+export class ScoutNestMiddleware {
+    private readonly _inner: ReturnType<typeof scoutMiddleware>;
+
+    constructor(opts?: ExpressMiddlewareOptions) {
+        this._inner = scoutMiddleware(opts);
+    }
+
+    use(req: any, res: any, next: () => void): void {
+        this._inner(req, res, next);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -43,10 +43,7 @@
     "test-integration-ejs": "tape 'dist/test/integrations/ejs.e2e.js'",
     "test-integration-express": "tape 'dist/test/integrations/express.e2e.js'",
     "test-integration-nuxt": "tape 'dist/test/integrations/nuxt.e2e.js'",
-    "test-integration-ioredis": "tape 'dist/test/integrations/ioredis.e2e.js'",
-    "test-integration-nest": "tape 'dist/test/integrations/nest.e2e.js'",
-    "test-integration-prisma": "tape 'dist/test/integrations/prisma.e2e.js'",
-    "generate": "prisma generate"
+    "test-integration-nest": "tape 'dist/test/integrations/nest.e2e.js'"
   },
   "types": "dist/lib/index.d.ts",
   "files": [
@@ -57,7 +54,6 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
-    "@prisma/client": "^5.22.0",
     "@scout_apm/scout-apm": "file:.",
     "@types/express": "^4.17.21",
     "@types/mysql": "^2.15.26",
@@ -79,6 +75,8 @@
     "prisma": "^5.22.0",
     "pug": "^3.0.3",
     "randomstring": "^1.3.0",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.0",
     "sequelize": "^6.37.5",
     "sha256-file": "^1.0.0",
     "supertest": "^7.0.0",

--- a/test/integration/nest.int.ts
+++ b/test/integration/nest.int.ts
@@ -1,0 +1,213 @@
+import "reflect-metadata";
+import test from "tape";
+import request from "supertest";
+import { NestFactory } from "@nestjs/core";
+import { Module, Controller, Get } from "@nestjs/common";
+import { MockAgent } from "./mock-agent";
+import { nestMiddleware } from "../../lib/nest";
+import { Scout } from "../../lib/scout";
+import { buildScoutConfiguration, ScoutEvent } from "../../lib/types";
+import { ScoutEventRequestSentData } from "../../lib/scout";
+import * as TestUtil from "../util";
+
+const TIMEOUT = 12000;
+
+// ── Minimal NestJS app used across all tests ─────────────────────────────────
+
+@Controller()
+class TestController {
+    @Get("/")
+    home() { return { status: "ok" }; }
+
+    @Get("/dynamic/:segment")
+    dynamic() { return { status: "ok" }; }
+}
+
+@Controller("api")
+class ApiController {
+    @Get("hello")
+    hello() { return { message: "hello" }; }
+}
+
+@Module({ controllers: [TestController, ApiController] })
+class TestModule {}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildConfig(mock: MockAgent, extra?: object) {
+    return buildScoutConfiguration({
+        allowShutdown: true,
+        monitor: true,
+        coreAgentDownload: false,
+        coreAgentLaunch: false,
+        socketPath: mock.socketPath(),
+        ...extra,
+    });
+}
+
+function nextRequestSent(scout: Scout, skipCount = 0): Promise<ScoutEventRequestSentData> {
+    return new Promise((resolve, reject) => {
+        let skipped = 0;
+        const timer = setTimeout(() => {
+            scout.removeListener(ScoutEvent.RequestSent, listener);
+            reject(new Error("Timed out waiting for ScoutEvent.RequestSent"));
+        }, TIMEOUT - 2000);
+
+        const listener = (data: ScoutEventRequestSentData) => {
+            if (!data.request.getChildSpansSync().some((s) => s.operation.startsWith("Controller/"))) {
+                return;
+            }
+            if (skipped < skipCount) { skipped++; return; }
+            clearTimeout(timer);
+            scout.removeListener(ScoutEvent.RequestSent, listener);
+            resolve(data);
+        };
+
+        scout.on(ScoutEvent.RequestSent, listener);
+    });
+}
+
+async function makeNestApp(scout: Scout): Promise<any> {
+    const app = await NestFactory.create(TestModule, { logger: false });
+    app.use(nestMiddleware({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+    await app.init();
+    return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test("NestJS GET / creates a Controller/GET span", { timeout: TIMEOUT }, (t) => {
+    const mock = new MockAgent();
+    let nestApp: any;
+    let scout: Scout;
+
+    mock.start()
+        .then(async () => {
+            scout = new Scout(buildConfig(mock));
+            nestApp = await makeNestApp(scout);
+            // warmup — initialises Scout connection
+            await request(nestApp.getHttpServer()).get("/").expect(200);
+        })
+        .then(() => {
+            const sentPromise = nextRequestSent(scout, 1);
+            request(nestApp.getHttpServer()).get("/").end(() => undefined);
+            return sentPromise;
+        })
+        .then((data) => {
+            const spans = data.request.getChildSpansSync();
+            const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+            t.ok(ctrl, "Controller span created");
+            t.ok(ctrl?.operation.includes("GET"), "span includes GET");
+            t.equal(ctrl?.operation, "Controller/GET /", "route path is /");
+        })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+            mock.stop().catch(() => undefined);
+            nestApp?.close().catch(() => undefined);
+            t.fail(err.message);
+            t.end();
+        });
+});
+
+test("NestJS dynamic route captures route pattern not concrete value", { timeout: TIMEOUT }, (t) => {
+    const mock = new MockAgent();
+    let nestApp: any;
+    let scout: Scout;
+
+    mock.start()
+        .then(async () => {
+            scout = new Scout(buildConfig(mock));
+            nestApp = await makeNestApp(scout);
+            await request(nestApp.getHttpServer()).get("/").expect(200);
+        })
+        .then(() => {
+            const sentPromise = nextRequestSent(scout, 1);
+            request(nestApp.getHttpServer()).get("/dynamic/hello-world").end(() => undefined);
+            return sentPromise;
+        })
+        .then((data) => {
+            const spans = data.request.getChildSpansSync();
+            const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+            t.ok(ctrl, "Controller span created for dynamic route");
+            t.ok(
+                ctrl?.operation.includes(":segment"),
+                `route pattern captured, got: ${ctrl?.operation}`,
+            );
+            t.notOk(
+                ctrl?.operation.includes("hello-world"),
+                "concrete value not in span operation",
+            );
+        })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+            mock.stop().catch(() => undefined);
+            nestApp?.close().catch(() => undefined);
+            t.fail(err.message);
+            t.end();
+        });
+});
+
+test("NestJS controller prefix is included in span operation", { timeout: TIMEOUT }, (t) => {
+    const mock = new MockAgent();
+    let nestApp: any;
+    let scout: Scout;
+
+    mock.start()
+        .then(async () => {
+            scout = new Scout(buildConfig(mock));
+            nestApp = await makeNestApp(scout);
+            await request(nestApp.getHttpServer()).get("/").expect(200);
+        })
+        .then(() => {
+            const sentPromise = nextRequestSent(scout, 1);
+            request(nestApp.getHttpServer()).get("/api/hello").end(() => undefined);
+            return sentPromise;
+        })
+        .then((data) => {
+            const spans = data.request.getChildSpansSync();
+            const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+            t.ok(ctrl, "Controller span created for prefixed route");
+            t.equal(ctrl?.operation, "Controller/GET /api/hello", "full path with prefix captured");
+        })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+            mock.stop().catch(() => undefined);
+            nestApp?.close().catch(() => undefined);
+            t.fail(err.message);
+            t.end();
+        });
+});
+
+test("NestJS mock agent receives Register message on connect", { timeout: TIMEOUT }, (t) => {
+    const mock = new MockAgent();
+    let nestApp: any;
+    let scout: Scout;
+
+    mock.start()
+        .then(async () => {
+            scout = new Scout(buildConfig(mock, { name: "nest-test-app", key: "test-key" }));
+            nestApp = await makeNestApp(scout);
+            await request(nestApp.getHttpServer()).get("/").expect(200);
+        })
+        .then(() => mock.waitForMessage("Register"))
+        .then((msg) => {
+            t.ok(msg, "Register message received");
+            t.equal(msg.type, "Register", "message type is Register");
+        })
+        .then(() => nestApp.close())
+        .then(() => scout.shutdown())
+        .then(() => mock.stop())
+        .then(() => t.end())
+        .catch((err) => {
+            mock.stop().catch(() => undefined);
+            nestApp?.close().catch(() => undefined);
+            t.fail(err.message);
+            t.end();
+        });
+});

--- a/test/integrations/nest.e2e.ts
+++ b/test/integrations/nest.e2e.ts
@@ -1,0 +1,124 @@
+import "reflect-metadata";
+import test from "tape";
+import request from "supertest";
+import { NestFactory } from "@nestjs/core";
+import { Module, Controller, Get, Res } from "@nestjs/common";
+import { setupRequireIntegrations } from "../../lib";
+import { buildScoutConfiguration, ScoutEvent } from "../../lib/types";
+import { Scout, ScoutEventRequestSentData } from "../../lib/scout";
+import { nestMiddleware } from "../../lib/nest";
+import * as TestUtil from "../util";
+import { ScoutContextName, ScoutSpanOperation } from "../../lib/types";
+
+setupRequireIntegrations(["mustache", "http"]);
+
+const TIMEOUT = 15000;
+
+// ── Shared test controllers ───────────────────────────────────────────────────
+
+@Controller()
+class BasicController {
+    @Get("/")
+    home() { return { status: "ok" }; }
+
+    @Get("/items/:id")
+    item() { return { status: "ok" }; }
+}
+
+@Module({ controllers: [BasicController] })
+class BasicModule {}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function nextRequestSent(scout: Scout, skipCount = 0): Promise<ScoutEventRequestSentData> {
+    return new Promise((resolve, reject) => {
+        let skipped = 0;
+        const timer = setTimeout(() => {
+            scout.removeListener(ScoutEvent.RequestSent, listener);
+            reject(new Error("Timed out waiting for ScoutEvent.RequestSent"));
+        }, TIMEOUT - 2000);
+
+        const listener = (data: ScoutEventRequestSentData) => {
+            if (!data.request.getChildSpansSync().some((s) => s.operation.startsWith("Controller/"))) {
+                return;
+            }
+            if (skipped < skipCount) { skipped++; return; }
+            clearTimeout(timer);
+            scout.removeListener(ScoutEvent.RequestSent, listener);
+            resolve(data);
+        };
+
+        scout.on(ScoutEvent.RequestSent, listener);
+    });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test("nestMiddleware is a function", (t) => {
+    t.equal(typeof nestMiddleware, "function", "nestMiddleware is exported");
+    t.equal(typeof nestMiddleware(), "function", "nestMiddleware() returns a middleware function");
+    t.end();
+});
+
+test("NestJS app instruments root route", { timeout: TIMEOUT }, (t) => {
+    const config = buildScoutConfiguration({ allowShutdown: true, monitor: true });
+    const scout = new Scout(config);
+    let nestApp: any;
+
+    NestFactory.create(BasicModule, { logger: false })
+        .then((app) => {
+            nestApp = app;
+            app.use(nestMiddleware({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+            return app.init();
+        })
+        .then(() => request(nestApp.getHttpServer()).get("/").expect(200))
+        .then(() => {
+            const sentPromise = nextRequestSent(scout, 1);
+            request(nestApp.getHttpServer()).get("/").end(() => undefined);
+            return sentPromise;
+        })
+        .then((data) => {
+            const spans = data.request.getChildSpansSync();
+            const ctrl = spans.find((s) => s.operation.startsWith("Controller/GET"));
+            t.ok(ctrl, "Controller/GET span present");
+            t.equal(ctrl?.operation, "Controller/GET /", "operation is Controller/GET /");
+        })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .catch((err) => {
+            nestApp?.close().catch(() => undefined);
+            TestUtil.shutdownScout(t, scout, err);
+        });
+});
+
+test("NestJS parameterised route captures pattern not value", { timeout: TIMEOUT }, (t) => {
+    const config = buildScoutConfiguration({ allowShutdown: true, monitor: true });
+    const scout = new Scout(config);
+    let nestApp: any;
+
+    NestFactory.create(BasicModule, { logger: false })
+        .then((app) => {
+            nestApp = app;
+            app.use(nestMiddleware({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+            return app.init();
+        })
+        .then(() => request(nestApp.getHttpServer()).get("/").expect(200))
+        .then(() => {
+            const sentPromise = nextRequestSent(scout, 1);
+            request(nestApp.getHttpServer()).get("/items/42").end(() => undefined);
+            return sentPromise;
+        })
+        .then((data) => {
+            const spans = data.request.getChildSpansSync();
+            const ctrl = spans.find((s) => s.operation.startsWith("Controller/GET"));
+            t.ok(ctrl, "Controller span created");
+            t.ok(ctrl?.operation.includes(":id"), `includes :id pattern — got ${ctrl?.operation}`);
+            t.notOk(ctrl?.operation.includes("42"), "concrete value 42 not in operation");
+        })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .catch((err) => {
+            nestApp?.close().catch(() => undefined);
+            TestUtil.shutdownScout(t, scout, err);
+        });
+});


### PR DESCRIPTION
## Summary

- Add NestJS middleware with NestJS-aware route matching (own implementation, not a wrapper around Express)
- Add nestErrorFilter() global exception filter for error monitoring
- Add NestJS integration tests

## Test plan

- [ ] NestJS requests appear with correct route names in APM
- [ ] nestErrorFilter() captures errors and preserves HTTP status codes for HttpException subclasses