### PR TITLE
Add httpProxy config option to pass --proxy flag to core-agent

### DIFF
--- a/dist/lib/agents/external-process.js
+++ b/dist/lib/agents/external-process.js
@@ -548,6 +548,9 @@ class ExternalProcessAgent extends events_1.EventEmitter {
         if (this.opts.logLevel) {
             args.push("--log-level", this.opts.logLevel);
         }
+        if (this.opts.proxyUrl) {
+            args.push("--proxy", this.opts.proxyUrl);
+        }
         this.logFn(`[scout/external-process] binary path: [${this.opts.binPath}]`, types_1.LogLevel.Debug);
         this.logFn(`[scout/external-process] args: [${args}]`, types_1.LogLevel.Debug);
         this.detachedProcess = (0, child_process_1.spawn)(this.opts.binPath, args, {

--- a/dist/lib/types/agent.d.ts
+++ b/dist/lib/types/agent.d.ts
@@ -121,6 +121,7 @@ export declare class ProcessOptions {
     readonly logFilePath?: string;
     readonly configFilePath?: string;
     readonly disallowLaunch?: boolean;
+    readonly proxyUrl?: string;
     readonly sendTimeoutMs: number;
     readonly socketTimeoutMs: number;
     readonly connPoolOpts?: ConnectionPoolOptions;

--- a/dist/lib/types/agent.js
+++ b/dist/lib/types/agent.js
@@ -140,6 +140,9 @@ class ProcessOptions {
             if (opts.disallowLaunch) {
                 this.disallowLaunch = opts.disallowLaunch;
             }
+            if (opts.proxyUrl) {
+                this.proxyUrl = opts.proxyUrl;
+            }
             if (opts.sendTimeoutMs) {
                 this.sendTimeoutMs = opts.sendTimeoutMs;
             }

--- a/dist/lib/types/config.js
+++ b/dist/lib/types/config.js
@@ -452,5 +452,6 @@ function buildProcessOptions(config) {
         disallowLaunch: !config.coreAgentLaunch,
         logFilePath: config.logFilePath,
         logLevel: config.logLevel || config.coreAgentLogLevel,
+        proxyUrl: config.httpProxy,
     };
 }

--- a/lib/agents/external-process.ts
+++ b/lib/agents/external-process.ts
@@ -625,6 +625,7 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
         if (this.opts.logFilePath) { args.push("--log-file", this.opts.logFilePath); }
         if (this.opts.configFilePath) { args.push("--config-file", this.opts.configFilePath); }
         if (this.opts.logLevel) { args.push("--log-level", this.opts.logLevel); }
+        if (this.opts.proxyUrl) { args.push("--proxy", this.opts.proxyUrl); }
 
         this.logFn(`[scout/external-process] binary path: [${this.opts.binPath}]`, LogLevel.Debug);
         this.logFn(`[scout/external-process] args: [${args}]`, LogLevel.Debug);

--- a/lib/types/agent.ts
+++ b/lib/types/agent.ts
@@ -199,6 +199,7 @@ export class ProcessOptions {
     public readonly logFilePath?: string;
     public readonly configFilePath?: string;
     public readonly disallowLaunch?: boolean;
+    public readonly proxyUrl?: string;
 
     // Amount of time to wait before timing out messages
     public readonly sendTimeoutMs: number = Constants.DEFAULT_AGENT_SEND_TIMEOUT_MS;
@@ -219,6 +220,7 @@ export class ProcessOptions {
             if (opts.configFilePath) { this.configFilePath = opts.configFilePath; }
             if (opts.connPoolOpts) { this.connPoolOpts = opts.connPoolOpts; }
             if (opts.disallowLaunch) { this.disallowLaunch = opts.disallowLaunch; }
+            if (opts.proxyUrl) { this.proxyUrl = opts.proxyUrl; }
             if (opts.sendTimeoutMs) { this.sendTimeoutMs = opts.sendTimeoutMs; }
             if (opts.socketTimeoutMs) { this.socketTimeoutMs = opts.socketTimeoutMs; }
         }

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -556,5 +556,6 @@ export function buildProcessOptions(config: Partial<ScoutConfiguration>): Partia
         disallowLaunch: !config.coreAgentLaunch,
         logFilePath: config.logFilePath,
         logLevel: config.logLevel || config.coreAgentLogLevel,
+        proxyUrl: config.httpProxy,
     };
 }


### PR DESCRIPTION
## Summary

- Add httpProxy configuration option
- Passes the value to core-agent via the --proxy flag

## Test plan

- [ ] Setting httpProxy routes core-agent traffic through the specified proxy