### PR TITLE
Add SCOUT_HOST/ingest_url configuration option

### DIFF
--- a/dist/lib/agents/external-process.js
+++ b/dist/lib/agents/external-process.js
@@ -551,6 +551,9 @@ class ExternalProcessAgent extends events_1.EventEmitter {
         if (this.opts.proxyUrl) {
             args.push("--proxy", this.opts.proxyUrl);
         }
+        if (this.opts.ingestUrl) {
+            args.push("--ingest-url", this.opts.ingestUrl);
+        }
         this.logFn(`[scout/external-process] binary path: [${this.opts.binPath}]`, types_1.LogLevel.Debug);
         this.logFn(`[scout/external-process] args: [${args}]`, types_1.LogLevel.Debug);
         this.detachedProcess = (0, child_process_1.spawn)(this.opts.binPath, args, {

--- a/dist/lib/types/agent.d.ts
+++ b/dist/lib/types/agent.d.ts
@@ -122,6 +122,7 @@ export declare class ProcessOptions {
     readonly configFilePath?: string;
     readonly disallowLaunch?: boolean;
     readonly proxyUrl?: string;
+    readonly ingestUrl?: string;
     readonly sendTimeoutMs: number;
     readonly socketTimeoutMs: number;
     readonly connPoolOpts?: ConnectionPoolOptions;

--- a/dist/lib/types/agent.js
+++ b/dist/lib/types/agent.js
@@ -143,6 +143,9 @@ class ProcessOptions {
             if (opts.proxyUrl) {
                 this.proxyUrl = opts.proxyUrl;
             }
+            if (opts.ingestUrl) {
+                this.ingestUrl = opts.ingestUrl;
+            }
             if (opts.sendTimeoutMs) {
                 this.sendTimeoutMs = opts.sendTimeoutMs;
             }

--- a/dist/lib/types/config.d.ts
+++ b/dist/lib/types/config.d.ts
@@ -42,6 +42,7 @@ export interface ScoutConfiguration {
     httpProxy: string;
     allowShutdown: boolean;
     monitor: boolean;
+    host: string;
     framework: string;
     frameworkVersion: string;
     apiVersion: string;

--- a/dist/lib/types/config.js
+++ b/dist/lib/types/config.js
@@ -216,6 +216,7 @@ exports.DEFAULT_SCOUT_CONFIGURATION = {
     key: "",
     name: "",
     appServer: "",
+    host: "",
     coreAgentDownload: true,
     coreAgentLaunch: true,
     coreAgentLogLevel: enum_1.LogLevel.Error,
@@ -453,5 +454,6 @@ function buildProcessOptions(config) {
         logFilePath: config.logFilePath,
         logLevel: config.logLevel || config.coreAgentLogLevel,
         proxyUrl: config.httpProxy,
+        ingestUrl: config.host || undefined,
     };
 }

--- a/lib/agents/external-process.ts
+++ b/lib/agents/external-process.ts
@@ -626,6 +626,7 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
         if (this.opts.configFilePath) { args.push("--config-file", this.opts.configFilePath); }
         if (this.opts.logLevel) { args.push("--log-level", this.opts.logLevel); }
         if (this.opts.proxyUrl) { args.push("--proxy", this.opts.proxyUrl); }
+        if (this.opts.ingestUrl) { args.push("--ingest-url", this.opts.ingestUrl); }
 
         this.logFn(`[scout/external-process] binary path: [${this.opts.binPath}]`, LogLevel.Debug);
         this.logFn(`[scout/external-process] args: [${args}]`, LogLevel.Debug);

--- a/lib/types/agent.ts
+++ b/lib/types/agent.ts
@@ -200,6 +200,7 @@ export class ProcessOptions {
     public readonly configFilePath?: string;
     public readonly disallowLaunch?: boolean;
     public readonly proxyUrl?: string;
+    public readonly ingestUrl?: string;
 
     // Amount of time to wait before timing out messages
     public readonly sendTimeoutMs: number = Constants.DEFAULT_AGENT_SEND_TIMEOUT_MS;
@@ -221,6 +222,7 @@ export class ProcessOptions {
             if (opts.connPoolOpts) { this.connPoolOpts = opts.connPoolOpts; }
             if (opts.disallowLaunch) { this.disallowLaunch = opts.disallowLaunch; }
             if (opts.proxyUrl) { this.proxyUrl = opts.proxyUrl; }
+            if (opts.ingestUrl) { this.ingestUrl = opts.ingestUrl; }
             if (opts.sendTimeoutMs) { this.sendTimeoutMs = opts.sendTimeoutMs; }
             if (opts.socketTimeoutMs) { this.socketTimeoutMs = opts.socketTimeoutMs; }
         }

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -202,6 +202,9 @@ export interface ScoutConfiguration {
     allowShutdown: boolean;
     monitor: boolean;
 
+    // Scout ingest host — passed to core-agent as --ingest-url (reads SCOUT_HOST env var)
+    host: string;
+
     // Framework
     framework: string;
     frameworkVersion: string;
@@ -237,6 +240,7 @@ export const DEFAULT_SCOUT_CONFIGURATION: Partial<ScoutConfiguration> = {
     key: "",
     name: "",
     appServer: "",
+    host: "",
 
     coreAgentDownload: true,
     coreAgentLaunch: true,
@@ -557,5 +561,6 @@ export function buildProcessOptions(config: Partial<ScoutConfiguration>): Partia
         logFilePath: config.logFilePath,
         logLevel: config.logLevel || config.coreAgentLogLevel,
         proxyUrl: config.httpProxy,
+        ingestUrl: config.host || undefined,
     };
 }


### PR DESCRIPTION
## Summary

- Add SCOUT_HOST / ingest_url config option to override the APM ingest endpoint
- Includes type declarations in dist

## Test plan

- [ ] Setting SCOUT_HOST routes APM data to the specified host
- [ ] TypeScript type declarations include the new config option