### PR TITLE
Add logPayloadContent config to log span and error payloads for debugging

### DIFF
--- a/dist/lib/scout/index.js
+++ b/dist/lib/scout/index.js
@@ -976,6 +976,9 @@ function sendThroughAgent(scout, msg, opts) {
         scout.log("[scout] monitoring disabled, not sending tag request", types_1.LogLevel.Warn);
         return Promise.reject(new Errors.MonitoringDisabled());
     }
+    if (config.logPayloadContent) {
+        scout.log(`[scout/payload] ${msg.constructor.name}: ${JSON.stringify(msg.json)}`, types_1.LogLevel.Info);
+    }
     if (opts && opts.async) {
         return agent.sendAsync(msg);
     }

--- a/dist/lib/types/config.d.ts
+++ b/dist/lib/types/config.d.ts
@@ -58,6 +58,7 @@ export interface ScoutConfiguration {
     collectRemoteIP: boolean;
     uriReporting: URIReportingLevel;
     disabledInstruments: string[];
+    logPayloadContent: boolean;
     coreAgentTriple: string;
     coreAgentFullName: string;
 }

--- a/dist/lib/types/config.js
+++ b/dist/lib/types/config.js
@@ -223,6 +223,7 @@ exports.DEFAULT_SCOUT_CONFIGURATION = {
     coreAgentPermissions: 700,
     coreAgentVersion: "v1.3.0", // can be exact tag name, or 'latest'
     disabledInstruments: [],
+    logPayloadContent: false,
     downloadUrl: "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",
     framework: "",
     frameworkVersion: "",
@@ -259,6 +260,7 @@ const ENV_TRANSFORMS = {
     SCOUT_DISABLED_INSTRUMENTS: v => v.split(","),
     SCOUT_IGNORE: v => v.split(","),
     SCOUT_MONITOR: v => v.toLowerCase() === "true",
+    SCOUT_LOG_PAYLOAD_CONTENT: v => v.toLowerCase() === "true",
 };
 /**
  * EnvConfigSource returns the values set from the environment

--- a/lib/scout/index.ts
+++ b/lib/scout/index.ts
@@ -1238,6 +1238,13 @@ export function sendThroughAgent<T extends BaseAgentRequest, R extends BaseAgent
         return Promise.reject(new Errors.MonitoringDisabled());
     }
 
+    if (config.logPayloadContent) {
+        scout.log(
+            `[scout/payload] ${msg.constructor.name}: ${JSON.stringify(msg.json)}`,
+            LogLevel.Info,
+        );
+    }
+
     if (opts && opts.async) {
         return agent.sendAsync(msg);
     }

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -230,6 +230,7 @@ export interface ScoutConfiguration {
 
     // Misc
     disabledInstruments: string[];
+    logPayloadContent: boolean;
 
     // Derived
     coreAgentTriple: string;
@@ -249,6 +250,7 @@ export const DEFAULT_SCOUT_CONFIGURATION: Partial<ScoutConfiguration> = {
     coreAgentVersion: "v1.3.0", // can be exact tag name, or 'latest'
 
     disabledInstruments: [],
+    logPayloadContent: false,
     downloadUrl: "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",
 
     framework: "",
@@ -312,6 +314,7 @@ const ENV_TRANSFORMS = {
     SCOUT_DISABLED_INSTRUMENTS: v => v.split(","),
     SCOUT_IGNORE: v => v.split(","),
     SCOUT_MONITOR: v => v.toLowerCase() === "true",
+    SCOUT_LOG_PAYLOAD_CONTENT: v => v.toLowerCase() === "true",
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add logPayloadContent config option (SCOUT_LOG_PAYLOAD_CONTENT env var)
- When enabled, logs span payloads and error payloads to console for debugging

## Test plan

- [ ] Setting logPayloadContent=true logs span payloads to console
- [ ] Setting logPayloadContent=true logs error payloads to console