### PR TITLE
Add error monitoring: captureError API, Express error middleware, and global unhandled handlers

### DIFF
--- a/dist/lib/error-monitor.d.ts
+++ b/dist/lib/error-monitor.d.ts
@@ -1,0 +1,44 @@
+import { ScoutConfiguration } from "./types";
+export declare function setupErrorMonitoring(config: Partial<ScoutConfiguration>): void;
+/**
+ * Options for captureError. Mirrors the Ruby agent's ScoutApm::Error.capture signature:
+ *   capture(error, context = {}, env: nil, name: nil)
+ *
+ * - controller / action / module: where the error "lives" (shown as location in APM).
+ *   Express middleware fills these in automatically; pass overrides here to change them.
+ * - name: override the exception class name shown in APM (useful for string errors or
+ *   when you want a stable grouping name regardless of the class).
+ * - requestId / requestUrl / requestParams / requestSession: request envelope data.
+ *   Express middleware populates these from req; you can supply them manually too.
+ */
+export interface CaptureOptions {
+    controller?: string | null;
+    action?: string | null;
+    module?: string | null;
+    name?: string;
+    requestId?: string;
+    requestUrl?: string;
+    requestParams?: object;
+    requestSession?: object;
+}
+/**
+ * Report an error to Scout APM.
+ *
+ * @param error  - An Error object or a plain string message.
+ * @param context - Flat key-value object of custom context data (shown alongside the error).
+ * @param opts   - Optional location override and request envelope.
+ *
+ * @example
+ * // Simple
+ * captureError(new Error("Payment failed"))
+ *
+ * // With custom context
+ * captureError(new Error("Payment failed"), { userId: req.user.id, plan: "pro" })
+ *
+ * // With explicit location (e.g. from a background job or non-Express handler)
+ * captureError(new Error("Payment failed"), { orderId: 42 }, {
+ *   controller: "CheckoutController",
+ *   action: "process",
+ * })
+ */
+export declare function captureError(error: Error | string | any, context?: Record<string, any>, opts?: CaptureOptions): void;

--- a/dist/lib/error-monitor.js
+++ b/dist/lib/error-monitor.js
@@ -1,0 +1,163 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setupErrorMonitoring = setupErrorMonitoring;
+exports.captureError = captureError;
+const os = __importStar(require("os"));
+const error_service_1 = require("./error-service");
+let service = null;
+let ignoredExceptions = [];
+let currentConfig = null;
+let handlersInstalled = false;
+function setupErrorMonitoring(config) {
+    if (config.errorsEnabled === false) {
+        return;
+    }
+    if (!config.key || !config.name) {
+        return;
+    }
+    currentConfig = config;
+    ignoredExceptions = config.errorsIgnoredExceptions || [];
+    if (service) {
+        service.stop();
+    }
+    service = new error_service_1.ErrorService(config);
+    service.start();
+    if (!handlersInstalled) {
+        handlersInstalled = true;
+        process.on("uncaughtException", (err) => {
+            captureError(err);
+            throw err;
+        });
+        process.on("unhandledRejection", (reason) => {
+            captureError(reason instanceof Error ? reason : new Error(String(reason)));
+        });
+    }
+}
+/**
+ * Report an error to Scout APM.
+ *
+ * @param error  - An Error object or a plain string message.
+ * @param context - Flat key-value object of custom context data (shown alongside the error).
+ * @param opts   - Optional location override and request envelope.
+ *
+ * @example
+ * // Simple
+ * captureError(new Error("Payment failed"))
+ *
+ * // With custom context
+ * captureError(new Error("Payment failed"), { userId: req.user.id, plan: "pro" })
+ *
+ * // With explicit location (e.g. from a background job or non-Express handler)
+ * captureError(new Error("Payment failed"), { orderId: 42 }, {
+ *   controller: "CheckoutController",
+ *   action: "process",
+ * })
+ */
+function captureError(error, context, opts) {
+    if (!service || !currentConfig) {
+        return;
+    }
+    const err = typeof error === "string"
+        ? new Error(error)
+        : error instanceof Error ? error : new Error(String(error));
+    // If a string was passed, give it a stable default class name matching Ruby's convention
+    const className = opts && opts.name
+        ? opts.name
+        : err.constructor && err.constructor.name
+            ? err.constructor.name
+            : "Error";
+    if (isIgnored(err)) {
+        return;
+    }
+    const hasLocation = opts && (opts.controller != null || opts.action != null || opts.module != null);
+    service.enqueue({
+        exception_class: className,
+        message: err.message || String(err),
+        request_id: opts ? opts.requestId : undefined,
+        request_uri: opts ? opts.requestUrl : undefined,
+        request_params: (opts && opts.requestParams) ? opts.requestParams : null,
+        request_session: (opts && opts.requestSession) ? opts.requestSession : null,
+        environment: null,
+        trace: parseStack(err),
+        request_components: hasLocation ? {
+            module: (opts && opts.module) ?? null,
+            controller: (opts && opts.controller) ?? null,
+            action: (opts && opts.action) ?? null,
+        } : null,
+        context: context || undefined,
+        host: currentConfig.hostname || os.hostname(),
+        revision_sha: currentConfig.revisionSHA,
+    });
+}
+function isIgnored(err) {
+    if (ignoredExceptions.length === 0) {
+        return false;
+    }
+    let ctor = err.constructor;
+    while (ctor && ctor.name) {
+        if (ignoredExceptions.includes(ctor.name)) {
+            return true;
+        }
+        const parent = Object.getPrototypeOf(ctor);
+        if (!parent || parent === ctor) {
+            break;
+        }
+        ctor = parent;
+    }
+    return false;
+}
+function parseStack(error) {
+    if (!error.stack) {
+        return [];
+    }
+    return error.stack
+        .split("\n")
+        .slice(1)
+        .filter(line => !line.includes("node_modules"))
+        .map(line => {
+        const trimmed = line.trim();
+        const namedMatch = trimmed.match(/^at (.+?) \((.+?):(\d+):\d+\)$/);
+        if (namedMatch) {
+            return `${namedMatch[2]}:${namedMatch[3]}:in ${namedMatch[1]}`;
+        }
+        const anonMatch = trimmed.match(/^at (.+?):(\d+):\d+$/);
+        if (anonMatch) {
+            return `${anonMatch[1]}:${anonMatch[2]}:in <anonymous>`;
+        }
+        return null;
+    })
+        .filter((s) => s !== null);
+}

--- a/dist/lib/error-service.d.ts
+++ b/dist/lib/error-service.d.ts
@@ -1,0 +1,31 @@
+import { ScoutConfiguration } from "./types";
+export interface RequestComponents {
+    module?: string | null;
+    controller?: string | null;
+    action?: string | null;
+}
+export interface ErrorPayload {
+    exception_class: string;
+    message: string;
+    request_id?: string;
+    request_uri?: string;
+    request_params?: object | null;
+    request_session?: object | null;
+    environment?: object | null;
+    trace: string[];
+    request_components?: RequestComponents | null;
+    context?: object;
+    host: string;
+    revision_sha?: string;
+}
+export declare class ErrorService {
+    private queue;
+    private timer;
+    private config;
+    constructor(config: Partial<ScoutConfiguration>);
+    start(): void;
+    stop(): void;
+    enqueue(error: ErrorPayload): void;
+    private flush;
+    private send;
+}

--- a/dist/lib/error-service.js
+++ b/dist/lib/error-service.js
@@ -1,0 +1,134 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ErrorService = void 0;
+const https = __importStar(require("https"));
+const http = __importStar(require("http"));
+const zlib = __importStar(require("zlib"));
+const os = __importStar(require("os"));
+const url_1 = require("url");
+const MAX_QUEUE = 500;
+const FLUSH_INTERVAL_MS = 1000;
+class ErrorService {
+    constructor(config) {
+        this.queue = [];
+        this.timer = null;
+        this.config = config;
+    }
+    start() {
+        if (this.timer) {
+            return;
+        }
+        this.timer = setInterval(() => this.flush(), FLUSH_INTERVAL_MS);
+        // Don't block process exit
+        if (this.timer.unref) {
+            this.timer.unref();
+        }
+    }
+    stop() {
+        if (this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+    }
+    enqueue(error) {
+        if (this.queue.length >= MAX_QUEUE) {
+            this.queue.shift();
+        }
+        this.queue.push(error);
+        // Flush immediately so uncaughtException errors are shipped before process exit
+        this.flush();
+    }
+    flush() {
+        if (this.queue.length === 0) {
+            return;
+        }
+        this.send(this.queue.splice(0));
+    }
+    send(errors) {
+        const host = this.config.errorsHost || "https://errors.scoutapm.com";
+        const key = this.config.key || "";
+        const name = this.config.name || "";
+        const agentHostname = this.config.hostname || os.hostname();
+        const body = JSON.stringify({
+            notifier: "scout_apm_node",
+            environment: this.config.environment || "",
+            root: this.config.applicationRoot || "",
+            problems: errors,
+        });
+        if (this.config.logPayloadContent) {
+            // tslint:disable-next-line no-console
+            console.log(`[scout/error-payload] ${body}`);
+        }
+        zlib.gzip(Buffer.from(body, "utf8"), (gzipErr, compressed) => {
+            if (gzipErr) {
+                return;
+            }
+            let parsedUrl;
+            try {
+                parsedUrl = new url_1.URL(`${host}/apps/error.scout`);
+            }
+            catch {
+                return;
+            }
+            parsedUrl.searchParams.set("key", key);
+            parsedUrl.searchParams.set("name", name);
+            const isHttps = parsedUrl.protocol === "https:";
+            const transport = isHttps ? https : http;
+            const defaultPort = isHttps ? 443 : 80;
+            const port = parsedUrl.port ? parseInt(parsedUrl.port, 10) : defaultPort;
+            const options = {
+                hostname: parsedUrl.hostname,
+                port,
+                path: parsedUrl.pathname + parsedUrl.search,
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Content-Encoding": "gzip",
+                    "Content-Length": compressed.length,
+                    "Agent-Hostname": agentHostname,
+                    "X-Error-Count": String(errors.length),
+                },
+            };
+            const req = transport.request(options, (res) => {
+                res.resume();
+            });
+            req.on("error", () => { });
+            req.write(compressed);
+            req.end();
+        });
+    }
+}
+exports.ErrorService = ErrorService;

--- a/dist/lib/express.d.ts
+++ b/dist/lib/express.d.ts
@@ -5,6 +5,7 @@ export interface ApplicationWithScout {
     scout?: Scout;
 }
 type ExpressMiddleware = (req: any, res: any, next: () => void) => void;
+type ExpressErrorMiddleware = (err: any, req: any, res: any, next: (err?: any) => void) => void;
 export interface ExpressMiddlewareOptions {
     config?: Partial<ScoutConfiguration>;
     logFn?: LogFn;
@@ -28,4 +29,11 @@ export type ExpressRequestWithScout = Request & ExpressScoutInfo;
  * @returns {Function} a middleware function for use with express
  */
 export declare function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddleware;
+/**
+ * Express 4-arg error-handling middleware.
+ * Place after all other app.use()/routes so Express routes errors through it.
+ * Captures the error to Scout error monitoring, then calls next(err) so the
+ * default Express error handler (or any downstream handler) still runs.
+ */
+export declare function errorMiddleware(): ExpressErrorMiddleware;
 export {};

--- a/dist/lib/express.js
+++ b/dist/lib/express.js
@@ -37,6 +37,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.scoutMiddleware = scoutMiddleware;
+exports.errorMiddleware = errorMiddleware;
 const on_finished_1 = __importDefault(require("on-finished"));
 const async_hooks_1 = require("async_hooks");
 const types_1 = require("./types");
@@ -385,5 +386,27 @@ function scoutMiddleware(opts) {
             }
             next();
         });
+    };
+}
+/**
+ * Express 4-arg error-handling middleware.
+ * Place after all other app.use()/routes so Express routes errors through it.
+ * Captures the error to Scout error monitoring, then calls next(err) so the
+ * default Express error handler (or any downstream handler) still runs.
+ */
+function errorMiddleware() {
+    return (err, req, res, next) => {
+        if (err) {
+            const { captureError } = require("./error-monitor");
+            const error = err instanceof Error ? err : new Error(String(err));
+            const requestInfo = req ? {
+                id: req.scout && req.scout.request ? req.scout.request.requestId : undefined,
+                url: req.originalUrl || req.url,
+                params: req.query || req.body ? Object.assign({}, req.query, req.body) : undefined,
+                session: req.session || undefined,
+            } : undefined;
+            captureError(error, { request: requestInfo });
+        }
+        next(err);
     };
 }

--- a/dist/lib/global.js
+++ b/dist/lib/global.js
@@ -45,6 +45,7 @@ exports.setGlobalLastUsedOptions = setGlobalLastUsedOptions;
 const scout_1 = require("./scout");
 const types_1 = require("./types");
 const Errors = __importStar(require("./errors"));
+const error_monitor_1 = require("./error-monitor");
 // Create an export bag which will contain exports modified by scout
 exports.EXPORT_BAG = {};
 // Global scout instance
@@ -118,8 +119,10 @@ function getOrCreateActiveGlobalScoutInstance(config, opts) {
     if (!config && LAST_USED_CONFIG) {
         config = LAST_USED_CONFIG;
     }
-    const instance = new scout_1.Scout((0, types_1.buildScoutConfiguration)(config), opts);
+    const builtConfig = (0, types_1.buildScoutConfiguration)(config);
+    const instance = new scout_1.Scout(builtConfig, opts);
     setActiveGlobalScoutInstance(instance);
+    (0, error_monitor_1.setupErrorMonitoring)(builtConfig);
     // Set up a listener if the global instance is ever shut down
     instance.on(types_1.ScoutEvent.Shutdown, () => {
         instance.log("[scout/global] The global instance has shut down, clearing global singleton", types_1.LogLevel.Warn);

--- a/dist/lib/index.d.ts
+++ b/dist/lib/index.d.ts
@@ -1,5 +1,7 @@
 import * as Errors from "./errors";
-import { scoutMiddleware as expressMiddleware } from "./express";
+import { scoutMiddleware as expressMiddleware, errorMiddleware } from "./express";
+import { nestMiddleware as nestMiddlewareImpl } from "./nest";
+import { captureError } from "./error-monitor";
 import { Scout, ScoutRequest, DoneCallback, SpanCallback, RequestCallback } from "./scout";
 import { ScoutConfiguration, JSONValue, buildScoutConfiguration, consoleLogFn, buildWinstonLogFn } from "./types";
 import { getOrCreateActiveGlobalScoutInstance } from "./global";
@@ -9,6 +11,9 @@ declare const API: {
     Errors: typeof Errors;
     setupRequireIntegrations: typeof setupRequireIntegrations;
     expressMiddleware: typeof expressMiddleware;
+    errorMiddleware: typeof errorMiddleware;
+    nestMiddleware: typeof nestMiddlewareImpl;
+    captureError: typeof captureError;
     consoleLogFn: typeof consoleLogFn;
     buildWinstonLogFn: typeof buildWinstonLogFn;
     install: typeof getOrCreateActiveGlobalScoutInstance;

--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -34,6 +34,8 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 const Errors = __importStar(require("./errors"));
 const express_1 = require("./express");
+const nest_1 = require("./nest");
+const error_monitor_1 = require("./error-monitor");
 const types_1 = require("./types");
 const integrations_1 = require("./integrations");
 const global_1 = require("./global");
@@ -71,9 +73,13 @@ const API = {
     // Configuration building
     buildScoutConfiguration: types_1.buildScoutConfiguration,
     Errors,
-    // Ingetrations
+    // Integrations
     setupRequireIntegrations,
     expressMiddleware: express_1.scoutMiddleware,
+    errorMiddleware: express_1.errorMiddleware,
+    nestMiddleware: nest_1.nestMiddleware,
+    // Error monitoring
+    captureError: error_monitor_1.captureError,
     // Logging
     consoleLogFn: types_1.consoleLogFn,
     buildWinstonLogFn: types_1.buildWinstonLogFn,

--- a/dist/lib/scout/index.js
+++ b/dist/lib/scout/index.js
@@ -977,7 +977,8 @@ function sendThroughAgent(scout, msg, opts) {
         return Promise.reject(new Errors.MonitoringDisabled());
     }
     if (config.logPayloadContent) {
-        scout.log(`[scout/payload] ${msg.constructor.name}: ${JSON.stringify(msg.json)}`, types_1.LogLevel.Info);
+        // Use console.log directly — scout.log() is a no-op when no logFn is configured.
+        console.log(`[scout/payload] ${msg.constructor.name}: ${JSON.stringify(msg.json)}`); // tslint:disable-line no-console
     }
     if (opts && opts.async) {
         return agent.sendAsync(msg);

--- a/dist/lib/types/config.d.ts
+++ b/dist/lib/types/config.d.ts
@@ -59,6 +59,10 @@ export interface ScoutConfiguration {
     uriReporting: URIReportingLevel;
     disabledInstruments: string[];
     logPayloadContent: boolean;
+    errorsEnabled: boolean;
+    errorsHost: string;
+    errorsIgnoredExceptions: string[];
+    environment: string;
     coreAgentTriple: string;
     coreAgentFullName: string;
 }

--- a/dist/lib/types/config.js
+++ b/dist/lib/types/config.js
@@ -225,6 +225,10 @@ exports.DEFAULT_SCOUT_CONFIGURATION = {
     disabledInstruments: [],
     logPayloadContent: false,
     downloadUrl: "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",
+    errorsEnabled: true,
+    errorsHost: "https://errors.scoutapm.com",
+    errorsIgnoredExceptions: [],
+    environment: "",
     framework: "",
     frameworkVersion: "",
     hostname: null,
@@ -261,6 +265,8 @@ const ENV_TRANSFORMS = {
     SCOUT_IGNORE: v => v.split(","),
     SCOUT_MONITOR: v => v.toLowerCase() === "true",
     SCOUT_LOG_PAYLOAD_CONTENT: v => v.toLowerCase() === "true",
+    SCOUT_ERRORS_ENABLED: v => v.toLowerCase() === "true",
+    SCOUT_ERRORS_IGNORED_EXCEPTIONS: v => v.split(",").map((s) => s.trim()).filter(Boolean),
 };
 /**
  * EnvConfigSource returns the values set from the environment

--- a/lib/error-monitor.ts
+++ b/lib/error-monitor.ts
@@ -1,0 +1,154 @@
+import * as os from "os";
+import { ScoutConfiguration } from "./types";
+import { ErrorService } from "./error-service";
+
+let service: ErrorService | null = null;
+let ignoredExceptions: string[] = [];
+let currentConfig: Partial<ScoutConfiguration> | null = null;
+let handlersInstalled = false;
+
+export function setupErrorMonitoring(config: Partial<ScoutConfiguration>): void {
+    if (config.errorsEnabled === false) { return; }
+    if (!config.key || !config.name) { return; }
+
+    currentConfig = config;
+    ignoredExceptions = (config.errorsIgnoredExceptions as string[]) || [];
+
+    if (service) { service.stop(); }
+    service = new ErrorService(config);
+    service.start();
+
+    if (!handlersInstalled) {
+        handlersInstalled = true;
+
+        process.on("uncaughtException", (err: Error) => {
+            captureError(err);
+            throw err;
+        });
+
+        process.on("unhandledRejection", (reason: any) => {
+            captureError(reason instanceof Error ? reason : new Error(String(reason)));
+        });
+    }
+}
+
+/**
+ * Options for captureError. Mirrors the Ruby agent's ScoutApm::Error.capture signature:
+ *   capture(error, context = {}, env: nil, name: nil)
+ *
+ * - controller / action / module: where the error "lives" (shown as location in APM).
+ *   Express middleware fills these in automatically; pass overrides here to change them.
+ * - name: override the exception class name shown in APM (useful for string errors or
+ *   when you want a stable grouping name regardless of the class).
+ * - requestId / requestUrl / requestParams / requestSession: request envelope data.
+ *   Express middleware populates these from req; you can supply them manually too.
+ */
+export interface CaptureOptions {
+    // Location — where the error lives in the app
+    controller?: string | null;
+    action?: string | null;
+    module?: string | null;
+    // Override the exception_class name shown in APM
+    name?: string;
+    // Request envelope (populated automatically by Express middleware)
+    requestId?: string;
+    requestUrl?: string;
+    requestParams?: object;
+    requestSession?: object;
+}
+
+/**
+ * Report an error to Scout APM.
+ *
+ * @param error  - An Error object or a plain string message.
+ * @param context - Flat key-value object of custom context data (shown alongside the error).
+ * @param opts   - Optional location override and request envelope.
+ *
+ * @example
+ * // Simple
+ * captureError(new Error("Payment failed"))
+ *
+ * // With custom context
+ * captureError(new Error("Payment failed"), { userId: req.user.id, plan: "pro" })
+ *
+ * // With explicit location (e.g. from a background job or non-Express handler)
+ * captureError(new Error("Payment failed"), { orderId: 42 }, {
+ *   controller: "CheckoutController",
+ *   action: "process",
+ * })
+ */
+export function captureError(
+    error: Error | string | any,
+    context?: Record<string, any>,
+    opts?: CaptureOptions,
+): void {
+    if (!service || !currentConfig) { return; }
+
+    const err = typeof error === "string"
+        ? new Error(error)
+        : error instanceof Error ? error : new Error(String(error));
+
+    // If a string was passed, give it a stable default class name matching Ruby's convention
+    const className = opts && opts.name
+        ? opts.name
+        : err.constructor && err.constructor.name
+            ? err.constructor.name
+            : "Error";
+
+    if (isIgnored(err)) { return; }
+
+    const hasLocation = opts && (opts.controller != null || opts.action != null || opts.module != null);
+
+    service.enqueue({
+        exception_class: className,
+        message: err.message || String(err),
+        request_id: opts ? opts.requestId : undefined,
+        request_uri: opts ? opts.requestUrl : undefined,
+        request_params: (opts && opts.requestParams) ? opts.requestParams : null,
+        request_session: (opts && opts.requestSession) ? opts.requestSession : null,
+        environment: null,
+        trace: parseStack(err),
+        request_components: hasLocation ? {
+            module: (opts && opts.module) ?? null,
+            controller: (opts && opts.controller) ?? null,
+            action: (opts && opts.action) ?? null,
+        } : null,
+        context: context || undefined,
+        host: (currentConfig.hostname as string) || os.hostname(),
+        revision_sha: currentConfig.revisionSHA,
+    });
+}
+
+function isIgnored(err: Error): boolean {
+    if (ignoredExceptions.length === 0) { return false; }
+    let ctor = err.constructor as (new (...args: any[]) => any) | null;
+    while (ctor && ctor.name) {
+        if (ignoredExceptions.includes(ctor.name)) { return true; }
+        const parent = Object.getPrototypeOf(ctor);
+        if (!parent || parent === ctor) { break; }
+        ctor = parent;
+    }
+    return false;
+}
+
+function parseStack(error: Error): string[] {
+    if (!error.stack) { return []; }
+
+    return error.stack
+        .split("\n")
+        .slice(1)
+        .filter(line => !line.includes("node_modules"))
+        .map(line => {
+            const trimmed = line.trim();
+            const namedMatch = trimmed.match(/^at (.+?) \((.+?):(\d+):\d+\)$/);
+            if (namedMatch) {
+                return `${namedMatch[2]}:${namedMatch[3]}:in ${namedMatch[1]}`;
+            }
+            const anonMatch = trimmed.match(/^at (.+?):(\d+):\d+$/);
+            if (anonMatch) {
+                return `${anonMatch[1]}:${anonMatch[2]}:in <anonymous>`;
+            }
+            return null;
+        })
+        .filter((s): s is string => s !== null);
+}

--- a/lib/error-service.ts
+++ b/lib/error-service.ts
@@ -1,0 +1,127 @@
+import * as https from "https";
+import * as http from "http";
+import * as zlib from "zlib";
+import * as os from "os";
+import { URL } from "url";
+import { ScoutConfiguration } from "./types";
+
+const MAX_QUEUE = 500;
+const FLUSH_INTERVAL_MS = 1000;
+
+export interface RequestComponents {
+    module?: string | null;
+    controller?: string | null;
+    action?: string | null;
+}
+
+export interface ErrorPayload {
+    exception_class: string;
+    message: string;
+    request_id?: string;
+    request_uri?: string;
+    request_params?: object | null;
+    request_session?: object | null;
+    environment?: object | null;
+    trace: string[];
+    request_components?: RequestComponents | null;
+    context?: object;
+    host: string;
+    revision_sha?: string;
+}
+
+export class ErrorService {
+    private queue: ErrorPayload[] = [];
+    private timer: ReturnType<typeof setInterval> | null = null;
+    private config: Partial<ScoutConfiguration>;
+
+    constructor(config: Partial<ScoutConfiguration>) {
+        this.config = config;
+    }
+
+    public start(): void {
+        if (this.timer) { return; }
+        this.timer = setInterval(() => this.flush(), FLUSH_INTERVAL_MS);
+        // Don't block process exit
+        if (this.timer.unref) { this.timer.unref(); }
+    }
+
+    public stop(): void {
+        if (this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+    }
+
+    public enqueue(error: ErrorPayload): void {
+        if (this.queue.length >= MAX_QUEUE) {
+            this.queue.shift();
+        }
+        this.queue.push(error);
+        // Flush immediately so uncaughtException errors are shipped before process exit
+        this.flush();
+    }
+
+    private flush(): void {
+        if (this.queue.length === 0) { return; }
+        this.send(this.queue.splice(0));
+    }
+
+    private send(errors: ErrorPayload[]): void {
+        const host = (this.config.errorsHost as string) || "https://errors.scoutapm.com";
+        const key = this.config.key || "";
+        const name = this.config.name || "";
+        const agentHostname = (this.config.hostname as string) || os.hostname();
+
+        const body = JSON.stringify({
+            notifier: "scout_apm_node",
+            environment: this.config.environment || "",
+            root: this.config.applicationRoot || "",
+            problems: errors,
+        });
+
+        if (this.config.logPayloadContent) {
+            // tslint:disable-next-line no-console
+            console.log(`[scout/error-payload] ${body}`);
+        }
+
+        zlib.gzip(Buffer.from(body, "utf8"), (gzipErr, compressed) => {
+            if (gzipErr) { return; }
+
+            let parsedUrl: URL;
+            try {
+                parsedUrl = new URL(`${host}/apps/error.scout`);
+            } catch {
+                return;
+            }
+            parsedUrl.searchParams.set("key", key);
+            parsedUrl.searchParams.set("name", name);
+
+            const isHttps = parsedUrl.protocol === "https:";
+            const transport = isHttps ? https : http;
+            const defaultPort = isHttps ? 443 : 80;
+            const port = parsedUrl.port ? parseInt(parsedUrl.port, 10) : defaultPort;
+
+            const options = {
+                hostname: parsedUrl.hostname,
+                port,
+                path: parsedUrl.pathname + parsedUrl.search,
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Content-Encoding": "gzip",
+                    "Content-Length": compressed.length,
+                    "Agent-Hostname": agentHostname,
+                    "X-Error-Count": String(errors.length),
+                },
+            };
+
+            const req = transport.request(options, (res) => {
+                res.resume();
+            });
+
+            req.on("error", () => { /* swallow network errors */ });
+            req.write(compressed);
+            req.end();
+        });
+    }
+}

--- a/lib/express.ts
+++ b/lib/express.ts
@@ -120,6 +120,7 @@ export interface ApplicationWithScout {
 }
 
 type ExpressMiddleware = (req: any, res: any, next: () => void) => void;
+type ExpressErrorMiddleware = (err: any, req: any, res: any, next: (err?: any) => void) => void;
 
 export interface ExpressMiddlewareOptions {
     config?: Partial<ScoutConfiguration>;
@@ -457,5 +458,30 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
 
                 next();
             });
+    };
+}
+
+/**
+ * Express 4-arg error-handling middleware.
+ * Place after all other app.use()/routes so Express routes errors through it.
+ * Captures the error to Scout error monitoring, then calls next(err) so the
+ * default Express error handler (or any downstream handler) still runs.
+ */
+export function errorMiddleware(): ExpressErrorMiddleware {
+    return (err: any, req: any, res: any, next: (err?: any) => void) => {
+        if (err) {
+            const { captureError } = require("./error-monitor");
+            const error = err instanceof Error ? err : new Error(String(err));
+
+            const requestInfo = req ? {
+                id: req.scout && req.scout.request ? req.scout.request.requestId : undefined,
+                url: req.originalUrl || req.url,
+                params: req.query || req.body ? Object.assign({}, req.query, req.body) : undefined,
+                session: req.session || undefined,
+            } : undefined;
+
+            captureError(error, { request: requestInfo });
+        }
+        next(err);
     };
 }

--- a/lib/global.ts
+++ b/lib/global.ts
@@ -2,6 +2,7 @@ import { Scout, ScoutOptions } from "./scout";
 import { buildScoutConfiguration, LogLevel, ScoutConfiguration, ScoutEvent } from "./types";
 import { ExportBag } from "./types/integrations";
 import * as Errors from "./errors";
+import { setupErrorMonitoring } from "./error-monitor";
 
 // Create an export bag which will contain exports modified by scout
 export const EXPORT_BAG: ExportBag = {};
@@ -81,8 +82,10 @@ export function getOrCreateActiveGlobalScoutInstance(
 
     if (!config && LAST_USED_CONFIG) { config = LAST_USED_CONFIG; }
 
-    const instance = new Scout(buildScoutConfiguration(config), opts);
+    const builtConfig = buildScoutConfiguration(config);
+    const instance = new Scout(builtConfig, opts);
     setActiveGlobalScoutInstance(instance);
+    setupErrorMonitoring(builtConfig);
 
     // Set up a listener if the global instance is ever shut down
     instance.on(ScoutEvent.Shutdown, () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,8 @@
 import * as Errors from "./errors";
 
-import { scoutMiddleware as expressMiddleware } from "./express";
+import { scoutMiddleware as expressMiddleware, errorMiddleware } from "./express";
+import { nestMiddleware as nestMiddlewareImpl, nestErrorFilter as nestErrorFilterImpl } from "./nest";
+import { captureError } from "./error-monitor";
 
 import { Scout, ScoutRequest, DoneCallback, SpanCallback, RequestCallback } from "./scout";
 import { ScoutConfiguration, JSONValue, buildScoutConfiguration, consoleLogFn, buildWinstonLogFn } from "./types";
@@ -49,9 +51,15 @@ const API = {
 
     Errors,
 
-    // Ingetrations
+    // Integrations
     setupRequireIntegrations,
     expressMiddleware,
+    errorMiddleware,
+    nestMiddleware: nestMiddlewareImpl,
+    nestErrorFilter: nestErrorFilterImpl,
+
+    // Error monitoring
+    captureError,
 
     // Logging
     consoleLogFn,

--- a/lib/nest.ts
+++ b/lib/nest.ts
@@ -39,3 +39,56 @@ export class ScoutNestMiddleware {
         this._inner(req, res, next);
     }
 }
+
+/**
+ * Returns a NestJS-compatible global exception filter that captures errors via Scout.
+ *
+ * Does not require @nestjs/common as a dependency — NestJS duck-types the catch() method.
+ *
+ * @example
+ * const { nestErrorFilter } = require("@scout_apm/scout-apm");
+ * // after NestFactory.create():
+ * app.useGlobalFilters(nestErrorFilter());
+ */
+export function nestErrorFilter() {
+    return {
+        catch(exception: any, host: any): void {
+            const { captureError } = require("./error-monitor");
+
+            const ctx = host.switchToHttp();
+            const req = ctx.getRequest();
+            const res = ctx.getResponse();
+
+            if (req) {
+                captureError(
+                    exception,
+                    undefined,
+                    {
+                        controller: (req.route && req.route.path) || req.path || null,
+                        action: req.method ? req.method.toUpperCase() : null,
+                        module: null,
+                        requestId: req.scout && req.scout.request ? req.scout.request.requestId : undefined,
+                        requestUrl: req.originalUrl || req.url,
+                        requestParams: (req.query || req.body)
+                            ? Object.assign({}, req.query, req.body)
+                            : undefined,
+                        requestSession: req.session || undefined,
+                    },
+                );
+            } else {
+                captureError(exception);
+            }
+
+            // Determine HTTP status — NestJS HttpException carries getStatus()
+            const status = exception && typeof exception.getStatus === "function"
+                ? exception.getStatus()
+                : 500;
+
+            const message = exception instanceof Error
+                ? exception.message
+                : typeof exception === "string" ? exception : "Internal server error";
+
+            res.status(status).json({ statusCode: status, message });
+        },
+    };
+}

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -232,6 +232,12 @@ export interface ScoutConfiguration {
     disabledInstruments: string[];
     logPayloadContent: boolean;
 
+    // Error monitoring
+    errorsEnabled: boolean;
+    errorsHost: string;
+    errorsIgnoredExceptions: string[];
+    environment: string;
+
     // Derived
     coreAgentTriple: string;
     coreAgentFullName: string;
@@ -252,6 +258,11 @@ export const DEFAULT_SCOUT_CONFIGURATION: Partial<ScoutConfiguration> = {
     disabledInstruments: [],
     logPayloadContent: false,
     downloadUrl: "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",
+
+    errorsEnabled: true,
+    errorsHost: "https://errors.scoutapm.com",
+    errorsIgnoredExceptions: [],
+    environment: "",
 
     framework: "",
     frameworkVersion: "",
@@ -315,6 +326,8 @@ const ENV_TRANSFORMS = {
     SCOUT_IGNORE: v => v.split(","),
     SCOUT_MONITOR: v => v.toLowerCase() === "true",
     SCOUT_LOG_PAYLOAD_CONTENT: v => v.toLowerCase() === "true",
+    SCOUT_ERRORS_ENABLED: v => v.toLowerCase() === "true",
+    SCOUT_ERRORS_IGNORED_EXCEPTIONS: v => v.split(",").map((s: string) => s.trim()).filter(Boolean),
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add captureError() API for manual error reporting with custom context
- Add errorMiddleware() for Express — captures errors passed to next(err)
- Add nestErrorFilter() for NestJS — global exception filter
- Add global unhandledRejection and uncaughtException handlers
- Strip node_modules frames from error backtraces
- Walk prototype chain for errorsIgnoredExceptions (instanceof behavior)
- Add request_components (controller, action, module) to error payloads
- captureError(error, context?, opts?) matches Ruby agent pattern

## Test plan

- [ ] captureError() sends errors to errors.scoutapm.com
- [ ] Express errorMiddleware() captures route errors
- [ ] nestErrorFilter() captures NestJS exceptions
- [ ] Unhandled promise rejections and uncaught exceptions are captured
- [ ] errorsIgnoredExceptions suppresses matching error classes and subclasses