### PR TITLE
Add init() single-call setup and node --require preload entry point

### DIFF
--- a/dist/lib/express.d.ts
+++ b/dist/lib/express.d.ts
@@ -1,6 +1,24 @@
 import { LogFn, ScoutConfiguration } from "./types";
 import { Scout, ScoutRequest, ScoutSpan } from "./scout";
 import { Request } from "express";
+export interface EndpointInfo {
+    path: string;
+    methods: string[];
+    middleware?: string[];
+    regex?: RegExp;
+}
+/**
+ * List all endpoints registered on an Express app.
+ * Works with both Express 4 and Express 5.
+ *
+ * Express 5 changed the internal router structure:
+ * - app.router instead of app._router
+ * - layer.matchers[] instead of layer.regexp
+ *
+ * The express-list-endpoints library doesn't support Express 5,
+ * so we implement our own walker for Express 5 and fall back to the library for Express 4.
+ */
+export declare function listExpressEndpoints(app: any): EndpointInfo[];
 export interface ApplicationWithScout {
     scout?: Scout;
 }
@@ -32,8 +50,11 @@ export declare function scoutMiddleware(opts?: ExpressMiddlewareOptions): Expres
 /**
  * Express 4-arg error-handling middleware.
  * Place after all other app.use()/routes so Express routes errors through it.
- * Captures the error to Scout error monitoring, then calls next(err) so the
- * default Express error handler (or any downstream handler) still runs.
+ * Captures the error to Scout error monitoring with location auto-detected from
+ * the request, then calls next(err) so downstream handlers still run.
+ *
+ * @example
+ * app.use(errorMiddleware())
  */
 export declare function errorMiddleware(): ExpressErrorMiddleware;
 export {};

--- a/dist/lib/express.js
+++ b/dist/lib/express.js
@@ -36,6 +36,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.listExpressEndpoints = listExpressEndpoints;
 exports.scoutMiddleware = scoutMiddleware;
 exports.errorMiddleware = errorMiddleware;
 const on_finished_1 = __importDefault(require("on-finished"));
@@ -66,8 +67,14 @@ function listExpressEndpoints(app) {
     }
     // Express 5: walk the router stack ourselves
     const endpoints = [];
-    // Express 4 uses app._router; Express 5 uses app.router (which throws on v4)
-    const router = app._router || app.router;
+    // Express 4 uses app._router; Express 5 uses app.router (a getter that throws on Express 4)
+    let router = app._router;
+    if (!router) {
+        try {
+            router = app.router;
+        }
+        catch { /* Express 4 getter throws */ }
+    }
     if (!router || !router.stack) {
         return endpoints;
     }
@@ -218,8 +225,14 @@ function scoutMiddleware(opts) {
         let matchedRouteMiddleware = commonRouteMiddlewares.find((m) => middlewareMatchesUrl(m, preQueryUrl));
         // If we couldn't find a route in the ones that have worked before,
         // then we have to search the router stack
-        // Express 4 uses app._router; Express 5 uses app.router (which throws on v4)
-        const appRouter = req.app._router || req.app.router;
+        // Express 4 uses _router; Express 5 uses router (a getter that throws on Express 4)
+        let appRouter = req.app._router;
+        if (!appRouter) {
+            try {
+                appRouter = req.app.router;
+            }
+            catch { /* Express 4 getter throws */ }
+        }
         if (!routePath && appRouter && appRouter.stack) {
             // Find routes that match the current URL
             matchedRouteMiddleware = appRouter.stack
@@ -391,21 +404,30 @@ function scoutMiddleware(opts) {
 /**
  * Express 4-arg error-handling middleware.
  * Place after all other app.use()/routes so Express routes errors through it.
- * Captures the error to Scout error monitoring, then calls next(err) so the
- * default Express error handler (or any downstream handler) still runs.
+ * Captures the error to Scout error monitoring with location auto-detected from
+ * the request, then calls next(err) so downstream handlers still run.
+ *
+ * @example
+ * app.use(errorMiddleware())
  */
 function errorMiddleware() {
     return (err, req, res, next) => {
         if (err) {
             const { captureError } = require("./error-monitor");
-            const error = err instanceof Error ? err : new Error(String(err));
-            const requestInfo = req ? {
-                id: req.scout && req.scout.request ? req.scout.request.requestId : undefined,
-                url: req.originalUrl || req.url,
-                params: req.query || req.body ? Object.assign({}, req.query, req.body) : undefined,
-                session: req.session || undefined,
-            } : undefined;
-            captureError(error, { request: requestInfo });
+            captureError(err, undefined, req ? {
+                // Location — auto-detected from the matched route; users can override
+                // by wrapping errorMiddleware or calling captureError directly.
+                controller: (req.route && req.route.path) || req.path || null,
+                action: req.method ? req.method.toUpperCase() : null,
+                module: null,
+                // Request envelope
+                requestId: req.scout && req.scout.request ? req.scout.request.requestId : undefined,
+                requestUrl: req.originalUrl || req.url,
+                requestParams: (req.query || req.body)
+                    ? Object.assign({}, req.query, req.body)
+                    : undefined,
+                requestSession: req.session || undefined,
+            } : undefined);
         }
         next(err);
     };

--- a/dist/lib/nest.d.ts
+++ b/dist/lib/nest.d.ts
@@ -1,20 +1,17 @@
-import { ExpressMiddlewareOptions } from "./express";
-/**
- * Scout APM middleware for NestJS.
- *
- * Register in main.ts before app.listen():
- *   app.use(nestMiddleware({ config }));
- *
- * Or with a class-based consumer:
- *   @Injectable()
- *   export class ScoutMiddleware implements NestMiddleware {
- *     use(req, res, next) { nestMiddleware()(req, res, next); }
- *   }
- */
-export declare function nestMiddleware(opts?: ExpressMiddlewareOptions): (req: any, res: any, next: () => void) => void;
+import { LogFn, ScoutConfiguration } from "./types";
+import { Scout } from "./scout";
+export type NestMiddlewareOptions = {
+    config?: Partial<ScoutConfiguration>;
+    logFn?: LogFn;
+    requestTimeoutMs?: number;
+    statisticsIntervalMS?: number;
+    scout?: Scout;
+    waitForScoutSetup?: boolean;
+};
+type NestMiddleware = (req: any, res: any, next: () => void) => void;
+export declare function nestMiddleware(opts?: NestMiddlewareOptions): NestMiddleware;
 /**
  * Class-based Scout middleware for use with NestJS's MiddlewareConsumer.
- * Satisfies NestMiddleware<Request, Response> without importing @nestjs/common.
  *
  * Example:
  *   @Module({})
@@ -26,6 +23,7 @@ export declare function nestMiddleware(opts?: ExpressMiddlewareOptions): (req: a
  */
 export declare class ScoutNestMiddleware {
     private readonly _inner;
-    constructor(opts?: ExpressMiddlewareOptions);
+    constructor(opts?: NestMiddlewareOptions);
     use(req: any, res: any, next: () => void): void;
 }
+export {};

--- a/dist/lib/nest.js
+++ b/dist/lib/nest.js
@@ -1,26 +1,208 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ScoutNestMiddleware = void 0;
 exports.nestMiddleware = nestMiddleware;
+const on_finished_1 = __importDefault(require("on-finished"));
+const async_hooks_1 = require("async_hooks");
+const types_1 = require("./types");
+const Constants = __importStar(require("./constants"));
+const global_1 = require("./global");
 const express_1 = require("./express");
-/**
- * Scout APM middleware for NestJS.
- *
- * Register in main.ts before app.listen():
- *   app.use(nestMiddleware({ config }));
- *
- * Or with a class-based consumer:
- *   @Injectable()
- *   export class ScoutMiddleware implements NestMiddleware {
- *     use(req, res, next) { nestMiddleware()(req, res, next); }
- *   }
- */
+const path_to_regexp_1 = require("path-to-regexp");
+const getNanoTime = require("nano-time");
+const BigNumber = require("big-number");
+// NestJS-specific route cache — separate from the Express middleware's cache so
+// the two don't interfere when both are used in the same process.
+const NEST_ROUTE_INFO_LOOKUP = {};
+const REQUEST_QUEUE_TIME_HEADERS = ["x-queue-start", "x-request-start"];
+function parseQueueTimeNS(value) {
+    if (!value) {
+        return null;
+    }
+    value = value.trim();
+    if (!value.startsWith("t=")) {
+        return null;
+    }
+    const parsed = new BigNumber(value.slice(2));
+    if (parsed.number === "Invalid Number") {
+        return null;
+    }
+    return parsed;
+}
 function nestMiddleware(opts) {
-    return (0, express_1.scoutMiddleware)(opts);
+    const overrides = opts && opts.config ? opts.config : {};
+    const config = (0, types_1.buildScoutConfiguration)(overrides);
+    const options = {
+        logFn: opts && opts.logFn ? opts.logFn : undefined,
+        statisticsIntervalMS: opts && opts.statisticsIntervalMS ? opts.statisticsIntervalMS : undefined,
+    };
+    (0, global_1.setGlobalLastUsedConfiguration)(config);
+    (0, global_1.setGlobalLastUsedOptions)(options);
+    return (req, res, next) => {
+        const requestStartTimeNS = getNanoTime();
+        const scout = opts && opts.scout ? opts.scout : req.app.scout || (0, global_1.getActiveGlobalScoutInstance)();
+        const setupScout = () => (0, global_1.getOrCreateActiveGlobalScoutInstance)(config, options)
+            .then(s => req.app.scout = s);
+        const waitForScoutSetup = opts && opts.waitForScoutSetup;
+        if (!scout && !waitForScoutSetup) {
+            setImmediate(setupScout);
+            next();
+            return;
+        }
+        if (!req || !req.app) {
+            if (opts && opts.logFn) {
+                opts.logFn(`[scout] Request object is missing/invalid (application object missing)`, types_1.LogLevel.Warn);
+            }
+            next();
+            return;
+        }
+        const reqUrl = req.url;
+        const preQueryUrl = reqUrl.split("?")[0];
+        // NestJS routes are always registered on a nested Express Router, never as
+        // top-level layers on app._router.  Skip the flat stack scan and go straight
+        // to listExpressEndpoints which walks the full nested tree.
+        let routePath = reqUrl === "/" ? "/" : null;
+        if (!routePath) {
+            try {
+                let matchedRoute = Object.values(NEST_ROUTE_INFO_LOOKUP).find(r => r.regex.exec(preQueryUrl));
+                if (!matchedRoute) {
+                    (0, express_1.listExpressEndpoints)(req.app).forEach(r => {
+                        NEST_ROUTE_INFO_LOOKUP[r.path] = {
+                            ...r,
+                            regex: (0, path_to_regexp_1.pathToRegexp)(r.path),
+                        };
+                    });
+                    matchedRoute = Object.values(NEST_ROUTE_INFO_LOOKUP).find(r => r.regex.exec(preQueryUrl));
+                }
+                if (matchedRoute) {
+                    routePath = matchedRoute.path;
+                }
+            }
+            catch (err) {
+                if (opts && opts.logFn) {
+                    opts.logFn(`[scout] Failed to determine route of request, [${req.originalUrl}]`, types_1.LogLevel.Warn);
+                }
+            }
+        }
+        let requestTimeoutMs = Constants.DEFAULT_EXPRESS_REQUEST_TIMEOUT_MS;
+        if (opts && "requestTimeoutMs" in opts) {
+            requestTimeoutMs = opts.requestTimeoutMs;
+        }
+        Promise.resolve(scout)
+            .then(s => {
+            if (!s && waitForScoutSetup) {
+                return setupScout();
+            }
+            return s;
+        })
+            .then(s => req.app.scout = s)
+            .then(s => s.setup())
+            .then(scout => {
+            if (!routePath) {
+                scout.emit(types_1.ScoutEvent.UnknownRequestPathSkipped, req.url);
+                next();
+                return;
+            }
+            const reqMethod = req.method.toUpperCase();
+            if (scout.ignoresPath(routePath)) {
+                next();
+                return;
+            }
+            req.scout = { instance: scout };
+            const name = `Controller/${reqMethod} ${routePath}`;
+            let transactionTimeout;
+            scout.transaction(name, (finishTransaction) => {
+                req.scout.request = scout.getCurrentRequest();
+                if (!req.scout.request) {
+                    if (opts && opts.logFn) {
+                        opts.logFn(`[scout] Failed to start transaction, no current request`, types_1.LogLevel.Warn);
+                    }
+                    next();
+                    return;
+                }
+                req.scout.request
+                    .addContext(types_1.ScoutContextName.Path, scout.filterRequestPath(reqUrl))
+                    .then(() => {
+                    const matchingHeader = REQUEST_QUEUE_TIME_HEADERS.find(h => req.get(h));
+                    if (matchingHeader) {
+                        const value = parseQueueTimeNS(req.get(matchingHeader));
+                        return req.scout.request.addContext(types_1.ScoutContextName.QueueTimeNS, new BigNumber(requestStartTimeNS).minus(value).toString());
+                    }
+                })
+                    .then(() => {
+                    scout.instrument(name, finishSpan => {
+                        if (requestTimeoutMs > 0) {
+                            transactionTimeout = setTimeout(() => {
+                                req.scout.request
+                                    .addContext(types_1.ScoutContextName.Timeout, "true")
+                                    .then(() => finishTransaction())
+                                    .catch(() => {
+                                    if (opts && opts.logFn) {
+                                        opts.logFn(`[scout] Failed to finish (timed out): ${req.scout.request}`, types_1.LogLevel.Warn);
+                                    }
+                                });
+                            }, requestTimeoutMs);
+                        }
+                        (0, on_finished_1.default)(res, () => {
+                            if (transactionTimeout) {
+                                clearTimeout(transactionTimeout);
+                            }
+                            finishTransaction().then(() => delete req.scout);
+                        });
+                        req.scout.rootSpan = scout.getCurrentSpan();
+                        // Re-enter Scout async context after any setImmediate dispatch
+                        // NestJS's router and Express 5 both use setImmediate internally.
+                        async_hooks_1.AsyncResource.bind(next)();
+                    });
+                });
+            });
+        })
+            .catch((err) => {
+            if (opts && opts.logFn) {
+                opts.logFn(`[scout] No scout instance on NestJS application:\n ${err}`, types_1.LogLevel.Error);
+            }
+            next();
+        });
+    };
 }
 /**
  * Class-based Scout middleware for use with NestJS's MiddlewareConsumer.
- * Satisfies NestMiddleware<Request, Response> without importing @nestjs/common.
  *
  * Example:
  *   @Module({})
@@ -32,7 +214,7 @@ function nestMiddleware(opts) {
  */
 class ScoutNestMiddleware {
     constructor(opts) {
-        this._inner = (0, express_1.scoutMiddleware)(opts);
+        this._inner = nestMiddleware(opts);
     }
     use(req, res, next) {
         this._inner(req, res, next);

--- a/dist/test/integration/express.int.js
+++ b/dist/test/integration/express.int.js
@@ -68,6 +68,11 @@ function nextRequestSent(scout, skipCount = 0) {
             reject(new Error("Timed out waiting for ScoutEvent.RequestSent"));
         }, TIMEOUT - 1000);
         const listener = (data) => {
+            // Ignore HTTP integration transactions (no Controller/ span) — they fire
+            // for supertest's outbound http.request() calls and would throw off skipCount.
+            if (!data.request.getChildSpansSync().some((s) => s.operation.startsWith("Controller/"))) {
+                return;
+            }
             if (skipped < skipCount) {
                 skipped++;
                 return;

--- a/dist/test/integration/libraries.int.js
+++ b/dist/test/integration/libraries.int.js
@@ -75,6 +75,11 @@ function nextRequestSent(scout, skipCount = 0) {
             reject(new Error("Timed out waiting for ScoutEvent.RequestSent"));
         }, TIMEOUT - 2000);
         const listener = (data) => {
+            // Ignore HTTP integration transactions (no Controller/ span) — they fire
+            // for supertest's outbound http.request() calls and would throw off skipCount.
+            if (!data.request.getChildSpansSync().some((s) => s.operation.startsWith("Controller/"))) {
+                return;
+            }
             if (skipped < skipCount) {
                 skipped++;
                 return;

--- a/lib/express.ts
+++ b/lib/express.ts
@@ -27,7 +27,7 @@ const getNanoTime = require("nano-time");
 const BigNumber = require("big-number");
 
 // Partial endpoint info returned by listExpressEndpoints (regex added later by caller)
-interface EndpointInfo {
+export interface EndpointInfo {
     path: string;
     methods: string[];
     middleware?: string[];
@@ -45,7 +45,7 @@ interface EndpointInfo {
  * The express-list-endpoints library doesn't support Express 5,
  * so we implement our own walker for Express 5 and fall back to the library for Express 4.
  */
-function listExpressEndpoints(app: any): EndpointInfo[] {
+export function listExpressEndpoints(app: any): EndpointInfo[] {
     // Try express-list-endpoints first (works for Express 4)
     const libResult = listExpressEndpointsLib(app);
     if (libResult && libResult.length > 0) {
@@ -55,8 +55,11 @@ function listExpressEndpoints(app: any): EndpointInfo[] {
     // Express 5: walk the router stack ourselves
     const endpoints: EndpointInfo[] = [];
 
-    // Express 4 uses app._router; Express 5 uses app.router (which throws on v4)
-    const router = app._router || app.router;
+    // Express 4 uses app._router; Express 5 uses app.router (a getter that throws on Express 4)
+    let router = app._router;
+    if (!router) {
+        try { router = app.router; } catch { /* Express 4 getter throws */ }
+    }
     if (!router || !router.stack) {
         return endpoints;
     }
@@ -266,8 +269,11 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
 
         // If we couldn't find a route in the ones that have worked before,
         // then we have to search the router stack
-        // Express 4 uses app._router; Express 5 uses app.router (which throws on v4)
-        const appRouter = req.app._router || req.app.router;
+        // Express 4 uses _router; Express 5 uses router (a getter that throws on Express 4)
+        let appRouter = req.app._router;
+        if (!appRouter) {
+            try { appRouter = req.app.router; } catch { /* Express 4 getter throws */ }
+        }
         if (!routePath && appRouter && appRouter.stack) {
             // Find routes that match the current URL
             matchedRouteMiddleware = appRouter.stack
@@ -464,23 +470,35 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
 /**
  * Express 4-arg error-handling middleware.
  * Place after all other app.use()/routes so Express routes errors through it.
- * Captures the error to Scout error monitoring, then calls next(err) so the
- * default Express error handler (or any downstream handler) still runs.
+ * Captures the error to Scout error monitoring with location auto-detected from
+ * the request, then calls next(err) so downstream handlers still run.
+ *
+ * @example
+ * app.use(errorMiddleware())
  */
 export function errorMiddleware(): ExpressErrorMiddleware {
     return (err: any, req: any, res: any, next: (err?: any) => void) => {
         if (err) {
             const { captureError } = require("./error-monitor");
-            const error = err instanceof Error ? err : new Error(String(err));
 
-            const requestInfo = req ? {
-                id: req.scout && req.scout.request ? req.scout.request.requestId : undefined,
-                url: req.originalUrl || req.url,
-                params: req.query || req.body ? Object.assign({}, req.query, req.body) : undefined,
-                session: req.session || undefined,
-            } : undefined;
-
-            captureError(error, { request: requestInfo });
+            captureError(
+                err,
+                undefined,
+                req ? {
+                    // Location — auto-detected from the matched route; users can override
+                    // by wrapping errorMiddleware or calling captureError directly.
+                    controller: (req.route && req.route.path) || req.path || null,
+                    action: req.method ? req.method.toUpperCase() : null,
+                    module: null,
+                    // Request envelope
+                    requestId: req.scout && req.scout.request ? req.scout.request.requestId : undefined,
+                    requestUrl: req.originalUrl || req.url,
+                    requestParams: (req.query || req.body)
+                        ? Object.assign({}, req.query, req.body)
+                        : undefined,
+                    requestSession: req.session || undefined,
+                } : undefined,
+            );
         }
         next(err);
     };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,16 +6,16 @@ import { captureError } from "./error-monitor";
 
 import { Scout, ScoutRequest, DoneCallback, SpanCallback, RequestCallback } from "./scout";
 import { ScoutConfiguration, JSONValue, buildScoutConfiguration, consoleLogFn, buildWinstonLogFn } from "./types";
-import { getIntegrationForPackage } from "./integrations";
+import { getIntegrationForPackage, KNOWN_PACKAGES } from "./integrations";
 import { getActiveGlobalScoutInstance, getOrCreateActiveGlobalScoutInstance, EXPORT_BAG } from "./global";
 
-// Set up PG integration
-// This is needed for use in Typescript projects since `import` will not
-// run global code unless you do a whole-file import
-function setupRequireIntegrations(packages: string[], scoutConfig?: Partial<ScoutConfiguration>) {
-    packages = packages || [];
-
-    packages.forEach(name => {
+// When called with no arguments, registers hooks for every known package.
+// When called with a list, registers only those packages.
+// Hooks are no-ops until the package is actually required — safe to call for
+// packages that aren't installed.
+function setupRequireIntegrations(packages?: string[]) {
+    const list = packages ?? KNOWN_PACKAGES;
+    list.forEach(name => {
         const integration = getIntegrationForPackage(name);
         if (integration) {
             integration.ritmHook(EXPORT_BAG);
@@ -23,27 +23,10 @@ function setupRequireIntegrations(packages: string[], scoutConfig?: Partial<Scou
     });
 }
 
-// For pure NodeJS contexts this will be run automatically
-setupRequireIntegrations([
-    // Databases
-    "pg",
-    "mysql",
-    "mysql2",
-
-    // Templating
-    "pug",
-    "mustache",
-    "ejs",
-
-    // Web frameworks
-    "express",
-    "nuxt",
-
-    // NodeJS internals
-    "http",
-    "https",
-    "fetch",
-]);
+// Auto-register all known integrations when the module is first loaded.
+// CJS users who require('@scout_apm/scout-apm') before other packages get
+// automatic instrumentation with no further setup.
+setupRequireIntegrations();
 
 const API = {
     // Configuration building
@@ -67,6 +50,15 @@ const API = {
 
     // Install scout
     install: getOrCreateActiveGlobalScoutInstance,
+
+    // init() — preferred single-call setup.
+    // Registers all RITM hooks synchronously (same as require('@scout_apm/scout-apm')
+    // at the top of your file), then kicks off async Scout setup.
+    // Use this instead of a separate setupRequireIntegrations() + install() pair.
+    init(config: Partial<ScoutConfiguration>): Promise<Scout> {
+        setupRequireIntegrations();
+        return getOrCreateActiveGlobalScoutInstance(config);
+    },
 
     // instrument
     instrument(op: string, cb: DoneCallback, scout?: Scout): Promise<any> {

--- a/lib/integrations/index.ts
+++ b/lib/integrations/index.ts
@@ -10,10 +10,28 @@ import nuxtIntegration from "./nuxt";
 import httpsIntegration from "./https";
 import ioredisIntegration from "./ioredis";
 import prismaIntegration from "./prisma";
-import redisIntegration from "./redis";
 import fetchIntegration from "./fetch";
+import redisIntegration from "./redis";
 import mongodbIntegration from "./mongodb";
 import { doNothingRequireIntegration, RequireIntegration } from "../types/integrations";
+
+export const KNOWN_PACKAGES: string[] = [
+    pgIntegration.getPackageName(),
+    mysqlIntegration.getPackageName(),
+    mysql2Integration.getPackageName(),
+    pugIntegration.getPackageName(),
+    mustacheIntegration.getPackageName(),
+    ejsIntegration.getPackageName(),
+    httpIntegration.getPackageName(),
+    expressIntegration.getPackageName(),
+    nuxtIntegration.getPackageName(),
+    httpsIntegration.getPackageName(),
+    ioredisIntegration.getPackageName(),
+    prismaIntegration.getPackageName(),
+    fetchIntegration.getPackageName(),
+    redisIntegration.getPackageName(),
+    mongodbIntegration.getPackageName(),
+];
 
 export function getIntegrationForPackage(pkg: string): RequireIntegration {
     switch (pkg) {
@@ -29,8 +47,8 @@ export function getIntegrationForPackage(pkg: string): RequireIntegration {
         case httpsIntegration.getPackageName(): return httpsIntegration;
         case ioredisIntegration.getPackageName(): return ioredisIntegration;
         case prismaIntegration.getPackageName(): return prismaIntegration;
-        case redisIntegration.getPackageName(): return redisIntegration;
         case fetchIntegration.getPackageName(): return fetchIntegration;
+        case redisIntegration.getPackageName(): return redisIntegration;
         case mongodbIntegration.getPackageName(): return mongodbIntegration;
         default: return doNothingRequireIntegration;
     }

--- a/lib/nest.ts
+++ b/lib/nest.ts
@@ -1,24 +1,217 @@
-import { scoutMiddleware, ExpressMiddlewareOptions } from "./express";
+import onFinished from "on-finished";
+import { AsyncResource } from "async_hooks";
+import {
+    LogFn,
+    LogLevel,
+    ScoutConfiguration,
+    ScoutContextName,
+    ScoutEvent,
+    buildScoutConfiguration,
+} from "./types";
+import * as Constants from "./constants";
+import { Scout, ScoutRequest, ScoutSpan, ScoutOptions } from "./scout";
+import {
+    getActiveGlobalScoutInstance,
+    getOrCreateActiveGlobalScoutInstance,
+    setGlobalLastUsedConfiguration,
+    setGlobalLastUsedOptions,
+} from "./global";
+import { listExpressEndpoints, EndpointInfo, ApplicationWithScout, ExpressScoutInfo } from "./express";
+import { pathToRegexp } from "path-to-regexp";
 
-/**
- * Scout APM middleware for NestJS.
- *
- * Register in main.ts before app.listen():
- *   app.use(nestMiddleware({ config }));
- *
- * Or with a class-based consumer:
- *   @Injectable()
- *   export class ScoutMiddleware implements NestMiddleware {
- *     use(req, res, next) { nestMiddleware()(req, res, next); }
- *   }
- */
-export function nestMiddleware(opts?: ExpressMiddlewareOptions) {
-    return scoutMiddleware(opts);
+const getNanoTime = require("nano-time");
+const BigNumber = require("big-number");
+
+export type NestMiddlewareOptions = {
+    config?: Partial<ScoutConfiguration>;
+    logFn?: LogFn;
+    requestTimeoutMs?: number;
+    statisticsIntervalMS?: number;
+    scout?: Scout;
+    waitForScoutSetup?: boolean;
+};
+
+// NestJS-specific route cache — separate from the Express middleware's cache so
+// the two don't interfere when both are used in the same process.
+const NEST_ROUTE_INFO_LOOKUP: { [key: string]: EndpointInfo & { regex: RegExp } } = {};
+
+const REQUEST_QUEUE_TIME_HEADERS = ["x-queue-start", "x-request-start"];
+
+function parseQueueTimeNS(value: string): any {
+    if (!value) { return null; }
+    value = value.trim();
+    if (!value.startsWith("t=")) { return null; }
+    const parsed = new BigNumber(value.slice(2));
+    if (parsed.number === "Invalid Number") { return null; }
+    return parsed;
+}
+
+type NestMiddleware = (req: any, res: any, next: () => void) => void;
+
+export function nestMiddleware(opts?: NestMiddlewareOptions): NestMiddleware {
+    const overrides = opts && opts.config ? opts.config : {};
+    const config: Partial<ScoutConfiguration> = buildScoutConfiguration(overrides);
+    const options: ScoutOptions = {
+        logFn: opts && opts.logFn ? opts.logFn : undefined,
+        statisticsIntervalMS: opts && opts.statisticsIntervalMS ? opts.statisticsIntervalMS : undefined,
+    };
+
+    setGlobalLastUsedConfiguration(config);
+    setGlobalLastUsedOptions(options);
+
+    return (req: any, res: any, next: () => void) => {
+        const requestStartTimeNS = getNanoTime();
+
+        const scout = opts && opts.scout ? opts.scout : req.app.scout || getActiveGlobalScoutInstance();
+
+        const setupScout = () =>
+            getOrCreateActiveGlobalScoutInstance(config, options)
+                .then(s => req.app.scout = s);
+
+        const waitForScoutSetup = opts && opts.waitForScoutSetup;
+
+        if (!scout && !waitForScoutSetup) {
+            setImmediate(setupScout);
+            next();
+            return;
+        }
+
+        if (!req || !req.app) {
+            if (opts && opts.logFn) {
+                opts.logFn(`[scout] Request object is missing/invalid (application object missing)`, LogLevel.Warn);
+            }
+            next();
+            return;
+        }
+
+        const reqUrl = req.url;
+        const preQueryUrl = reqUrl.split("?")[0];
+
+        // NestJS routes are always registered on a nested Express Router, never as
+        // top-level layers on app._router.  Skip the flat stack scan and go straight
+        // to listExpressEndpoints which walks the full nested tree.
+        let routePath: string | null = reqUrl === "/" ? "/" : null;
+
+        if (!routePath) {
+            try {
+                let matchedRoute = Object.values(NEST_ROUTE_INFO_LOOKUP).find(r => r.regex.exec(preQueryUrl));
+
+                if (!matchedRoute) {
+                    listExpressEndpoints(req.app).forEach(r => {
+                        NEST_ROUTE_INFO_LOOKUP[r.path] = {
+                            ...r,
+                            regex: pathToRegexp(r.path),
+                        };
+                    });
+                    matchedRoute = Object.values(NEST_ROUTE_INFO_LOOKUP).find(r => r.regex.exec(preQueryUrl));
+                }
+
+                if (matchedRoute) {
+                    routePath = matchedRoute.path;
+                }
+            } catch (err) {
+                if (opts && opts.logFn) {
+                    opts.logFn(`[scout] Failed to determine route of request, [${req.originalUrl}]`, LogLevel.Warn);
+                }
+            }
+        }
+
+        let requestTimeoutMs = Constants.DEFAULT_EXPRESS_REQUEST_TIMEOUT_MS;
+        if (opts && "requestTimeoutMs" in opts) {
+            requestTimeoutMs = opts.requestTimeoutMs!;
+        }
+
+        Promise.resolve(scout)
+            .then(s => {
+                if (!s && waitForScoutSetup) { return setupScout(); }
+                return s;
+            })
+            .then(s => req.app.scout = s)
+            .then(s => s.setup())
+            .then(scout => {
+                if (!routePath) {
+                    scout.emit(ScoutEvent.UnknownRequestPathSkipped, req.url);
+                    next();
+                    return;
+                }
+
+                const reqMethod = req.method.toUpperCase();
+
+                if (scout.ignoresPath(routePath)) {
+                    next();
+                    return;
+                }
+
+                req.scout = { instance: scout } as ExpressScoutInfo;
+
+                const name = `Controller/${reqMethod} ${routePath}`;
+                let transactionTimeout: any;
+
+                scout.transaction(name, (finishTransaction) => {
+                    req.scout.request = scout.getCurrentRequest();
+                    if (!req.scout.request) {
+                        if (opts && opts.logFn) {
+                            opts.logFn(`[scout] Failed to start transaction, no current request`, LogLevel.Warn);
+                        }
+                        next();
+                        return;
+                    }
+
+                    req.scout.request
+                        .addContext(ScoutContextName.Path, scout.filterRequestPath(reqUrl))
+                        .then(() => {
+                            const matchingHeader = REQUEST_QUEUE_TIME_HEADERS.find(h => req.get(h));
+                            if (matchingHeader) {
+                                const value = parseQueueTimeNS(req.get(matchingHeader));
+                                return req.scout.request.addContext(
+                                    ScoutContextName.QueueTimeNS,
+                                    new BigNumber(requestStartTimeNS).minus(value).toString(),
+                                );
+                            }
+                        })
+                        .then(() => {
+                            scout.instrument(name, finishSpan => {
+                                if (requestTimeoutMs > 0) {
+                                    transactionTimeout = setTimeout(() => {
+                                        req.scout.request
+                                            .addContext(ScoutContextName.Timeout, "true")
+                                            .then(() => finishTransaction())
+                                            .catch(() => {
+                                                if (opts && opts.logFn) {
+                                                    opts.logFn(
+                                                        `[scout] Failed to finish (timed out): ${req.scout.request}`,
+                                                        LogLevel.Warn,
+                                                    );
+                                                }
+                                            });
+                                    }, requestTimeoutMs);
+                                }
+
+                                onFinished(res, () => {
+                                    if (transactionTimeout) { clearTimeout(transactionTimeout); }
+                                    finishTransaction().then(() => delete req.scout);
+                                });
+
+                                req.scout.rootSpan = scout.getCurrentSpan();
+
+                                // Re-enter Scout async context after any setImmediate dispatch
+                                // NestJS's router and Express 5 both use setImmediate internally.
+                                AsyncResource.bind(next)();
+                            });
+                        });
+                });
+            })
+            .catch((err: Error) => {
+                if (opts && opts.logFn) {
+                    opts.logFn(`[scout] No scout instance on NestJS application:\n ${err}`, LogLevel.Error);
+                }
+                next();
+            });
+    };
 }
 
 /**
  * Class-based Scout middleware for use with NestJS's MiddlewareConsumer.
- * Satisfies NestMiddleware<Request, Response> without importing @nestjs/common.
  *
  * Example:
  *   @Module({})
@@ -29,10 +222,10 @@ export function nestMiddleware(opts?: ExpressMiddlewareOptions) {
  *   }
  */
 export class ScoutNestMiddleware {
-    private readonly _inner: ReturnType<typeof scoutMiddleware>;
+    private readonly _inner: NestMiddleware;
 
-    constructor(opts?: ExpressMiddlewareOptions) {
-        this._inner = scoutMiddleware(opts);
+    constructor(opts?: NestMiddlewareOptions) {
+        this._inner = nestMiddleware(opts);
     }
 
     use(req: any, res: any, next: () => void): void {

--- a/lib/preload.ts
+++ b/lib/preload.ts
@@ -1,0 +1,19 @@
+/**
+ * Preload entry point for `node --require @scout_apm/scout-apm/preload`.
+ *
+ * Registers RITM hooks for all known packages before any user code runs.
+ * Full Scout configuration happens later when you call install() or init()
+ * in your application code.
+ *
+ * Usage:
+ *   node --require @scout_apm/scout-apm/preload app.js
+ */
+import { getIntegrationForPackage, KNOWN_PACKAGES } from "./integrations";
+import { EXPORT_BAG } from "./global";
+
+KNOWN_PACKAGES.forEach(name => {
+    const integration = getIntegrationForPackage(name);
+    if (integration) {
+        integration.ritmHook(EXPORT_BAG);
+    }
+});

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
     "generate": "prisma generate"
   },
   "types": "dist/lib/index.d.ts",
+  "exports": {
+    ".": "./dist/lib/index.js",
+    "./preload": "./dist/lib/preload.js"
+  },
   "files": [
     "index.d.ts",
     "dist/lib/**/*"


### PR DESCRIPTION
## Summary

- Add init(config) — single-call setup that registers all RITM hooks synchronously then starts Scout async
- Add lib/preload.ts for node --require @scout_apm/scout-apm/preload zero-config instrumentation
- Export KNOWN_PACKAGES from integrations index (single source of truth)
- setupRequireIntegrations() with no args now registers all known packages (ioredis, redis, prisma, mongodb, fetch included)
- Wire up ./preload subpath in package.json exports map

## Test plan

- [ ] init(config) registers hooks and starts Scout in a single call
- [ ] node --require @scout_apm/scout-apm/preload instruments all known packages automatically
- [ ] All previously registered packages still work