### PR TITLE
Upgrade uuid

### DIFF
--- a/dist/lib/protocol/v1/requests.js
+++ b/dist/lib/protocol/v1/requests.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.V1ApplicationEvent = exports.V1TagSpan = exports.V1StopSpan = exports.V1StartSpan = exports.V1TagRequest = exports.V1FinishRequest = exports.V1StartRequest = exports.V1Register = exports.V1GetVersionRequest = void 0;
 const uuid_1 = require("uuid");
 const Constants = require("../../constants");
 const types_1 = require("../../types");
@@ -31,7 +32,7 @@ class V1StartRequest extends types_1.BaseAgentRequest {
         this.type = types_1.AgentRequestType.V1StartRequest;
         const prefix = Constants.DEFAULT_REQUEST_PREFIX;
         this.timestamp = opts && opts.timestamp ? opts.timestamp : new Date();
-        this.requestId = opts && opts.requestId ? opts.requestId : `${prefix}${uuid_1.v4()}`;
+        this.requestId = opts && opts.requestId ? opts.requestId : `${prefix}${(0, uuid_1.v4)()}`;
         this.json = {
             StartRequest: {
                 request_id: this.requestId,
@@ -81,7 +82,7 @@ class V1StartSpan extends types_1.BaseAgentRequest {
         this.operation = operation;
         this.parentId = opts && opts.parentId ? opts.parentId : undefined;
         const prefix = Constants.DEFAULT_SPAN_PREFIX;
-        this.spanId = opts && opts.spanId ? opts.spanId : `${prefix}${uuid_1.v4()}`;
+        this.spanId = opts && opts.spanId ? opts.spanId : `${prefix}${(0, uuid_1.v4)()}`;
         this.timestamp = opts && opts.timestamp ? opts.timestamp : new Date();
         this.json = {
             StartSpan: {

--- a/dist/lib/scout/index.d.ts
+++ b/dist/lib/scout/index.d.ts
@@ -21,9 +21,9 @@ export interface CallbackInfo {
     parent?: ScoutSpan | ScoutRequest;
     request?: ScoutRequest;
 }
-export declare type DoneCallback = (done: () => void, info: CallbackInfo) => any;
-export declare type SpanCallback = (info: CallbackInfo) => any;
-export declare type RequestCallback = (info: CallbackInfo) => any;
+export type DoneCallback = (done: () => void, info: CallbackInfo) => any;
+export type SpanCallback = (info: CallbackInfo) => any;
+export type RequestCallback = (info: CallbackInfo) => any;
 export declare class Scout extends EventEmitter {
     private readonly config;
     private downloader;

--- a/dist/lib/scout/index.js
+++ b/dist/lib/scout/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.sendThroughAgent = exports.sendStopSpan = exports.sendTagSpan = exports.sendStartSpan = exports.sendTagRequest = exports.sendStopRequest = exports.sendStartRequest = exports.Scout = exports.ScoutSpan = exports.ScoutRequest = void 0;
 const events_1 = require("events");
 const path = require("path");
 const process = require("process");
@@ -17,9 +18,9 @@ const Requests = require("../protocol/v1/requests");
 const Constants = require("../constants");
 const Errors = require("../errors");
 var request_1 = require("./request");
-exports.ScoutRequest = request_1.default;
+Object.defineProperty(exports, "ScoutRequest", { enumerable: true, get: function () { return request_1.default; } });
 var span_1 = require("./span");
-exports.ScoutSpan = span_1.default;
+Object.defineProperty(exports, "ScoutSpan", { enumerable: true, get: function () { return span_1.default; } });
 const request_2 = require("./request");
 const DONE_NOTHING = () => undefined;
 class Scout extends events_1.EventEmitter {
@@ -30,7 +31,7 @@ class Scout extends events_1.EventEmitter {
         this.syncCurrentRequest = null;
         this.syncCurrentSpan = null;
         this.cpuUsageStart = getCPUUsage();
-        this.config = config || types_1.buildScoutConfiguration();
+        this.config = config || (0, types_1.buildScoutConfiguration)();
         if (opts) {
             if (opts.logFn) {
                 this.logFn = opts.logFn;
@@ -51,12 +52,12 @@ class Scout extends events_1.EventEmitter {
             version = version.slice(1);
         }
         // Build expected bin & socket path based on current version
-        const triple = types_1.generateTriple();
+        const triple = (0, types_1.generateTriple)();
         this.binPath = path.join(Constants.DEFAULT_CORE_AGENT_DOWNLOAD_CACHE_DIR, `scout_apm_core-v${version}-${triple}`, Constants.CORE_AGENT_BIN_FILE_NAME);
         // If the passed-in logging function (saved @ logFn) has a 'logger' property which has a correposnding level
         // attempt to set the log level to the passed in logger's level
-        if (this.logFn && this.logFn.logger && this.logFn.logger.level && types_1.isLogLevel(this.logFn.logger.level)) {
-            this.config.logLevel = types_1.parseLogLevel(this.logFn.logger.level);
+        if (this.logFn && this.logFn.logger && this.logFn.logger.level && (0, types_1.isLogLevel)(this.logFn.logger.level)) {
+            this.config.logLevel = (0, types_1.parseLogLevel)(this.logFn.logger.level);
         }
         // Create async namespace if it does not exist
         this.createAsyncNamespace();
@@ -68,7 +69,7 @@ class Scout extends events_1.EventEmitter {
         if (!this.config || !this.config.logLevel) {
             return;
         }
-        if (types_1.isIgnoredLogMessage(this.config.logLevel, level)) {
+        if ((0, types_1.isIgnoredLogMessage)(this.config.logLevel, level)) {
             return;
         }
         return this.logFn(message, level);
@@ -219,7 +220,7 @@ class Scout extends events_1.EventEmitter {
             process.on("uncaughtException", this.uncaughtExceptionListenerFn);
         })
             // Set up this scout instance as the global one, if there isn't already one
-            .then(() => global_1.setActiveGlobalScoutInstance(this))
+            .then(() => (0, global_1.setActiveGlobalScoutInstance)(this))
             // Start the statistics sending interval
             .then(() => this.startSendingStatistics())
             .then(() => this);
@@ -286,9 +287,9 @@ class Scout extends events_1.EventEmitter {
     filterRequestPath(path) {
         switch (this.config.uriReporting) {
             case types_1.URIReportingLevel.FilteredParams:
-                return types_1.scrubRequestPathParams(path);
+                return (0, types_1.scrubRequestPathParams)(path);
             case types_1.URIReportingLevel.Path:
-                return types_1.scrubRequestPath(path);
+                return (0, types_1.scrubRequestPath)(path);
             default:
                 return path;
         }
@@ -523,7 +524,7 @@ class Scout extends events_1.EventEmitter {
     // Setup integrations
     setupIntegrations() {
         Object.keys(global_1.EXPORT_BAG)
-            .map(packageName => integrations_1.getIntegrationForPackage(packageName))
+            .map(packageName => (0, integrations_1.getIntegrationForPackage)(packageName))
             .forEach(integration => integration.setScoutInstance(this));
     }
     /**
@@ -534,12 +535,12 @@ class Scout extends events_1.EventEmitter {
     agentIsRunning(socketPath) {
         const socketType = this.getSocketType();
         if (socketType === types_1.AgentSocketType.Unix) {
-            return fs_extra_1.pathExists(socketPath);
+            return (0, fs_extra_1.pathExists)(socketPath);
         }
         if (socketType === types_1.AgentSocketType.TCP) {
             const [_, __, portRaw] = socketPath.split(":");
             const port = parseInt(portRaw, 10);
-            return tcp_port_used_1.check(port);
+            return (0, tcp_port_used_1.check)(port);
         }
         return Promise.reject(new Errors.UnknownSocketType());
     }
@@ -574,7 +575,7 @@ class Scout extends events_1.EventEmitter {
         })
             // Build process options and agent
             .then(() => {
-            this.processOptions = new types_1.ProcessOptions(this.binPath, this.getSocketPath(), types_1.buildProcessOptions(this.config));
+            this.processOptions = new types_1.ProcessOptions(this.binPath, this.getSocketPath(), (0, types_1.buildProcessOptions)(this.config));
             return new external_process_1.default(this.processOptions, this.log);
         })
             .then(agent => this.setupAgent(agent));
@@ -594,7 +595,7 @@ class Scout extends events_1.EventEmitter {
         this.downloaderOptions = Object.assign({
             cacheDir: path.dirname(this.binPath),
             updateCache: true,
-        }, this.downloaderOptions, types_1.buildDownloadOptions(this.config));
+        }, this.downloaderOptions, (0, types_1.buildDownloadOptions)(this.config));
         // Download the appropriate binary
         return this.downloader
             .download(this.coreAgentVersion, this.downloaderOptions)
@@ -604,7 +605,7 @@ class Scout extends events_1.EventEmitter {
         })
             // Build options for the agent and create the agent
             .then(() => {
-            this.processOptions = new types_1.ProcessOptions(this.binPath, this.getSocketPath(), types_1.buildProcessOptions(this.config));
+            this.processOptions = new types_1.ProcessOptions(this.binPath, this.getSocketPath(), (0, types_1.buildProcessOptions)(this.config));
             const agent = new external_process_1.default(this.processOptions, this.log);
             if (!agent) {
                 throw new Errors.NoAgentPresent();

--- a/dist/lib/scout/request.js
+++ b/dist/lib/scout/request.js
@@ -16,7 +16,7 @@ class ScoutRequest {
         this.tags = {};
         this.ignored = false;
         this.logFn = () => undefined;
-        this.id = opts && opts.id ? opts.id : `${Constants.DEFAULT_REQUEST_PREFIX}${uuid_1.v4()}`;
+        this.id = opts && opts.id ? opts.id : `${Constants.DEFAULT_REQUEST_PREFIX}${(0, uuid_1.v4)()}`;
         if (opts) {
             if (opts.logFn) {
                 this.logFn = opts.logFn;
@@ -213,14 +213,14 @@ class ScoutRequest {
             inst.emit(types_2.ScoutEvent.IgnoredRequestProcessingSkipped, this);
             return Promise.resolve(this);
         }
-        this.sending = index_1.sendStartRequest(inst, this)
+        this.sending = (0, index_1.sendStartRequest)(inst, this)
             // Send all the child spans
             .then(() => Promise.all(this.childSpans.map(s => s.send())))
             // Send tags
             .then(() => Promise.all(Object.entries(this.tags)
-            .map(([name, value]) => index_1.sendTagRequest(inst, this, name, value))))
+            .map(([name, value]) => (0, index_1.sendTagRequest)(inst, this, name, value))))
             // End the span
-            .then(() => index_1.sendStopRequest(inst, this))
+            .then(() => (0, index_1.sendStopRequest)(inst, this))
             .then(() => this.sent = true)
             .then(() => this)
             .catch(err => {

--- a/dist/lib/scout/span.js
+++ b/dist/lib/scout/span.js
@@ -18,7 +18,7 @@ class ScoutSpan {
         this.ignored = false;
         this.logFn = () => undefined;
         this.requestId = opts.requestId;
-        this.id = opts && opts.id ? opts.id : `${Constants.DEFAULT_SPAN_PREFIX}${uuid_1.v4()}`;
+        this.id = opts && opts.id ? opts.id : `${Constants.DEFAULT_SPAN_PREFIX}${(0, uuid_1.v4)()}`;
         this.operation = opts.operation;
         if (opts) {
             if (opts.logFn) {
@@ -231,14 +231,14 @@ class ScoutSpan {
             return Promise.resolve(this);
         }
         // Start Span
-        this.sending = index_1.sendStartSpan(inst, this)
+        this.sending = (0, index_1.sendStartSpan)(inst, this)
             // Send all the child spans
             .then(() => Promise.all(this.childSpans.map(s => s.send())))
             // Send tags
             .then(() => Promise.all(Object.entries(this.tags)
-            .map(([name, value]) => index_1.sendTagSpan(inst, this, name, value))))
+            .map(([name, value]) => (0, index_1.sendTagSpan)(inst, this, name, value))))
             // End the span
-            .then(() => index_1.sendStopSpan(inst, this))
+            .then(() => (0, index_1.sendStopSpan)(inst, this))
             .then(() => this.sent = true)
             .then(() => this)
             .catch(err => {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "@types/semver": "5.5.0",
     "@types/tape": "4.2.33",
     "@types/tmp": "0.0.34",
-    "@types/uuid": "3.4.4",
     "app-root-path": "^3.0.0",
     "tslib": "^2.8.1",
     "big-number": "^2.0.0",
@@ -133,7 +132,7 @@
     "tcp-port-used": "^1.0.2",
     "tmp": "0.0.33",
     "tmp-promise": "1.0.5",
-    "uuid": "3.3.2",
+    "uuid": "^11.0.0",
     "winston": "^3.2.1"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrades `uuid` from v3.3.2 to v11 (recommended for CommonJS codebases per the deprecation notice)
- Removes `@types/uuid` — uuid ships its own types since v7
- No code changes required: `import { v4 as uuidv4 } from "uuid"` is unchanged

## Why v11 and not v14?

The npm deprecation message explicitly states: *"For CommonJS codebases, use uuid@11"*. v14+ may drop CJS support. This codebase compiles to CommonJS (`"module": "commonjs"` in tsconfig).

## Test plan

- [ ] Existing unit/integration tests pass
- [ ] `uuidv4()` still produces valid v4 UUIDs at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)