### PR TITLE
fix: daemonize core-agent and remove worker-owned process lifecycle

### DIFF
--- a/dist/lib/agents/external-process.d.ts
+++ b/dist/lib/agents/external-process.d.ts
@@ -1,7 +1,9 @@
 /// <reference types="node" />
+/// <reference types="node" />
+/// <reference types="node" />
+/// <reference types="node" />
 import { EventEmitter } from "events";
 import { Socket } from "net";
-import { ChildProcess } from "child_process";
 import { Agent, AgentStatus, AgentType, BaseAgentRequest, BaseAgentResponse, LogFn, ProcessOptions } from "../types";
 import { V1ApplicationEventResponse, V1RegisterResponse } from "../protocol/v1/responses";
 import { V1Register, V1ApplicationEvent } from "../protocol/v1/requests";
@@ -14,7 +16,7 @@ export interface ExtraSocketInfo {
     chunks?: Buffer;
     onFailure?: () => void;
 }
-export declare type ScoutSocket = Socket & ExtraSocketInfo;
+export type ScoutSocket = Socket & ExtraSocketInfo;
 export default class ExternalProcessAgent extends EventEmitter implements Agent {
     private readonly agentType;
     private readonly opts;
@@ -23,7 +25,6 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
     private maxPoolErrors;
     private socketConnected;
     private socketConnectionAttempts;
-    private detachedProcess;
     private stopped;
     private logFn;
     private registrationMsg;
@@ -48,9 +49,10 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
     /**
      * Check if the process is present
      */
-    getProcess(): Promise<ChildProcess>;
     /**
-     * Stop the process (if one is running)
+     * No-op: the core agent is a daemon and manages its own lifecycle.
+     * Workers must not kill it — doing so would take down all other workers
+     * sharing the same socket.
      */
     stopProcess(): Promise<void>;
     /**

--- a/dist/lib/agents/external-process.js
+++ b/dist/lib/agents/external-process.js
@@ -46,9 +46,9 @@ class ExternalProcessAgent extends events_1.EventEmitter {
     start() {
         return this.peerRunning()
             .then(exists => {
-            // If the socket doesn't already exist, start the process as configured
             if (exists) {
-                this.logFn("[scout/external-process] Socket already present", types_1.LogLevel.Warn);
+                this.logFn("[scout/external-process] Core agent already running, skipping launch", types_1.LogLevel.Debug);
+                return this;
             }
             return this.startProcess();
         });
@@ -219,39 +219,18 @@ class ExternalProcessAgent extends events_1.EventEmitter {
                 this.emit(types_1.AgentEvent.RequestSent, msg);
             });
         });
-        return promise_timeout_1.timeout(sendPromise, this.opts.sendTimeoutMs);
+        return (0, promise_timeout_1.timeout)(sendPromise, this.opts.sendTimeoutMs);
     }
     /**
      * Check if the process is present
      */
-    getProcess() {
-        if (this.opts.disallowLaunch) {
-            return Promise.reject(new Errors.NoProcessReference("launch disabled"));
-        }
-        if (this.detachedProcess === undefined || this.detachedProcess === null) {
-            return Promise.reject(new Errors.NoProcessReference());
-        }
-        return Promise.resolve(this.detachedProcess);
-    }
     /**
-     * Stop the process (if one is running)
+     * No-op: the core agent is a daemon and manages its own lifecycle.
+     * Workers must not kill it — doing so would take down all other workers
+     * sharing the same socket.
      */
     stopProcess() {
-        return this.getProcess()
-            .then(p => {
-            this.stopped = true;
-            // The process tree itself must be killed
-            // otherwise instances of core-agent may be leaked.
-            if (process.platform === "linux" && p.pid !== undefined) {
-                process.kill(-1 * p.pid);
-            }
-            p.kill();
-        })
-            // Remove the socket path
-            .then(() => fs_extra_1.remove(this.getSocketPath()))
-            .catch(err => {
-            this.logFn(`[scout/external-process] Process stop failed:\n${err}`, types_1.LogLevel.Error);
-        });
+        return Promise.resolve();
     }
     /**
      * Set the registration and metadata that will be used by the agent
@@ -271,10 +250,10 @@ class ExternalProcessAgent extends events_1.EventEmitter {
      */
     peerRunning() {
         if (this.opts.isDomainSocket()) {
-            return fs_extra_1.pathExists(this.getSocketPath());
+            return (0, fs_extra_1.pathExists)(this.getSocketPath());
         }
         if (this.opts.isTCPSocket()) {
-            return tcp_port_used_1.check(Constants.CORE_AGENT_TCP_DEFAULT_PORT);
+            return (0, tcp_port_used_1.check)(Constants.CORE_AGENT_TCP_DEFAULT_PORT);
         }
         return Promise.reject(new Errors.UnknownSocketType());
     }
@@ -287,12 +266,12 @@ class ExternalProcessAgent extends events_1.EventEmitter {
         if (!this.opts.isValidSocket()) {
             return Promise.reject(new Errors.NotSupported("Only domain (file:// | unix://) or TCP (tcp://) sockets are supported"));
         }
-        this.pool = generic_pool_1.createPool({
+        this.pool = (0, generic_pool_1.createPool)({
             create: () => {
                 // If there is at least one pool error, let's wait a bit between creating domain sockets
                 let maybeWait = () => Promise.resolve();
                 if (this.poolErrors.length > DOMAIN_SOCKET_CREATE_ERR_THRESHOLD) {
-                    maybeWait = () => types_1.waitMs(DOMAIN_SOCKET_CREATE_BACKOFF_MS);
+                    maybeWait = () => (0, types_1.waitMs)(DOMAIN_SOCKET_CREATE_BACKOFF_MS);
                 }
                 return maybeWait().then(() => this.createSocket());
             },
@@ -333,12 +312,12 @@ class ExternalProcessAgent extends events_1.EventEmitter {
             };
             // Perform the right connection based on the type of socket
             if (this.opts.isDomainSocket()) {
-                socket = net_1.createConnection(this.getSocketPath(), cb);
+                socket = (0, net_1.createConnection)(this.getSocketPath(), cb);
             }
             else if (this.opts.isTCPSocket()) {
                 const [host, portRaw] = this.getSocketPath().split(":");
                 const port = parseInt(portRaw, 10);
-                socket = net_1.createConnection(port, host, cb);
+                socket = (0, net_1.createConnection)(port, host, cb);
             }
             else {
                 reject(new Error("Unrecognized connection, neither domain nor TCP"));
@@ -423,13 +402,13 @@ class ExternalProcessAgent extends events_1.EventEmitter {
         }
         let framed = [];
         // Parse the buffer to return zero or more well-framed agent responses
-        const { framed: newFramed, remaining: newRemaining } = types_1.splitAgentResponses(data);
+        const { framed: newFramed, remaining: newRemaining } = (0, types_1.splitAgentResponses)(data);
         framed = framed.concat(newFramed);
         // Add the remaining to the partial response buffer we're keeping
         socket.chunks = Buffer.concat([socket.chunks, newRemaining]);
         // Attempt to extract any *just* completed messages
         // Update the partial response for any remaining
-        const { framed: chunkFramed, remaining: chunkRemaining } = types_1.splitAgentResponses(socket.chunks);
+        const { framed: chunkFramed, remaining: chunkRemaining } = (0, types_1.splitAgentResponses)(socket.chunks);
         framed = framed.concat(chunkFramed);
         socket.chunks = chunkRemaining;
         // Read all (likely) fully formed, correctly framed messages
@@ -503,6 +482,7 @@ class ExternalProcessAgent extends events_1.EventEmitter {
         const socketPath = this.getSocketPath();
         const args = [
             "start",
+            "--daemonize", "true",
             this.opts.isTCPSocket() ? "--tcp" : "--socket",
             socketPath,
         ];
@@ -523,11 +503,11 @@ class ExternalProcessAgent extends events_1.EventEmitter {
         }
         this.logFn(`[scout/external-process] binary path: [${this.opts.binPath}]`, types_1.LogLevel.Debug);
         this.logFn(`[scout/external-process] args: [${args}]`, types_1.LogLevel.Debug);
-        this.detachedProcess = child_process_1.spawn(this.opts.binPath, args, {
+        const proc = (0, child_process_1.spawn)(this.opts.binPath, args, {
             detached: true,
             stdio: "ignore",
         });
-        this.detachedProcess.unref();
+        proc.unref();
         // Wait until process is listening on the given socket port
         return new Promise((resolve, reject) => {
             setTimeout(() => {

--- a/dist/lib/scout/index.js
+++ b/dist/lib/scout/index.js
@@ -242,11 +242,7 @@ class Scout extends events_1.EventEmitter {
         }
         return this.agent
             .disconnect()
-            .then(() => {
-            if (this.config.allowShutdown && this.agent) {
-                return this.agent.stopProcess();
-            }
-        })
+            .then(() => undefined)
             // Remove the agent, emit the shutdown event
             .then(() => {
             this.agent = null;

--- a/dist/lib/types/config.js
+++ b/dist/lib/types/config.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildProcessOptions = exports.buildDownloadOptions = exports.buildScoutConfiguration = exports.ScoutConfigurationProxy = exports.generateTriple = exports.detectPlatformTriple = exports.DEFAULT_SCOUT_CONFIGURATION = exports.ApplicationMetadata = void 0;
 const os_1 = require("os");
 const process_1 = require("process");
 const os = require("os");
@@ -243,7 +244,7 @@ class EnvConfigSource {
         if (typeof prop === "symbol") {
             return this.env[prop];
         }
-        const envVar = util_1.convertCamelCaseToEnvVar(prop);
+        const envVar = (0, util_1.convertCamelCaseToEnvVar)(prop);
         let val = this.env[envVar];
         if (typeof val !== "undefined" && envVar in ENV_TRANSFORMS) {
             val = ENV_TRANSFORMS[envVar](val);
@@ -303,7 +304,7 @@ class DerivedConfigSource {
 }
 // Detect the machine architecture
 function detectArch() {
-    switch (os_1.arch()) {
+    switch ((0, os_1.arch)()) {
         case "x64": return enum_1.Architecture.X86_64;
         case "x32": return enum_1.Architecture.I686;
         default:
@@ -314,7 +315,7 @@ function detectArch() {
 function detectPlatform() {
     // Default to Musl Linux, even on glibc-enabled distros
     // https://github.com/scoutapp/scout_apm_node/issues/174
-    switch (os_1.platform()) {
+    switch ((0, os_1.platform)()) {
         case "linux": return enum_1.Platform.LinuxMusl;
         case "darwin": return enum_1.Platform.Darwin;
         default:

--- a/dist/test/agent-downloaders/web.e2e.js
+++ b/dist/test/agent-downloaders/web.e2e.js
@@ -27,7 +27,7 @@ test("cache is updated by download (v1.1.8)", { skip: SKIP_DOWNLOAD_TESTS }, t =
     let subdir = `scout_apm_core-v${version.raw}`;
     let expectedDirPath;
     let expectedBinPath;
-    types_1.detectPlatformTriple()
+    (0, types_1.detectPlatformTriple)()
         .then(platform => subdir = `${subdir}-${platform}`)
         .then(() => downloader.download(version, opts))
         .then(() => {

--- a/dist/test/agents/external-process.e2e.js
+++ b/dist/test/agents/external-process.e2e.js
@@ -13,16 +13,13 @@ const TEST_AGENT_KEY = process.env.TEST_AGENT_KEY || "fake-agent-key";
 const SKIP_BINARY_TESTS = process.env.ENABLE_BINARY_TESTS !== "true";
 test(`external process can be launched locally (v${TestConstants.TEST_APP_VERSION})`, { skip: SKIP_BINARY_TESTS }, t => {
     let agent;
-    let process;
     // Create the external process agent
     TestUtil.bootstrapExternalProcessAgent(t, TestConstants.TEST_APP_VERSION)
         .then(a => agent = a)
-        // Start the agent & check it was started by viewing the process
         .then(() => agent.start())
-        .then(() => agent.getProcess())
-        .then(p => process = p)
-        .then(() => t.assert(process, "process was started by this agent"))
-        // Cleanup the process & end test
+        .then(() => agent.connect())
+        .then(status => t.assert(status.connected, "agent is connected after start"))
+        // Cleanup & end test
         .then(() => TestUtil.cleanup(t, agent))
         .catch(err => TestUtil.cleanup(t, agent, err));
 });
@@ -456,18 +453,15 @@ test(`Request with 'Controller' span works, after waiting for flush (v${TestCons
         .catch(err => TestUtil.cleanup(t, agent, err));
 });
 test("Support starting scout with a completely external core-agent", { skip: SKIP_BINARY_TESTS }, t => {
-    // Create the external process agent, with special function for building the proc opts with
+    let agent;
+    // Create the external process agent with launch disabled — simulates connecting to an
+    // externally-managed daemon.
     TestUtil.bootstrapExternalProcessAgent(t, TestConstants.TEST_APP_VERSION, { buildProcOpts: (binPath, uri) => new types_1.ProcessOptions(binPath, uri, { disallowLaunch: true }) })
-        // Attempt to shut down the agent immediately which shouldn't work because there is no process
-        .then(agent => agent.getProcess())
-        // Cleanup the process & end test
-        .then(() => {
-        t.fail("shutdown succeeded on an agent with no process");
-        t.end();
-    })
+        .then(a => agent = a)
+        .then(() => agent.start())
         .catch(err => {
-        if (err instanceof Errors.NoProcessReference) {
-            t.pass("NoProcessReference error was returned");
+        if (err instanceof Errors.AgentLaunchDisabled) {
+            t.pass("AgentLaunchDisabled error returned when launch is disabled");
             t.end();
             return;
         }
@@ -480,7 +474,7 @@ test("Timeout agent messages", { skip: SKIP_BINARY_TESTS }, t => {
     let tmpSocketPath;
     const [socketServer, shutdownSocketServer] = TestUtil.createClientCollectingServer();
     // Create a temp directory for the do-nothing server's socket
-    fs_extra_1.mkdtemp("/tmp/timeout-test-")
+    (0, fs_extra_1.mkdtemp)("/tmp/timeout-test-")
         .then(dir => tmpSocketPath = path.join(dir, "core-agent.sock"))
         // Create the socket server that will count connections
         .then(() => socketServer.listen(tmpSocketPath))

--- a/dist/test/agents/external-process.e2e.js
+++ b/dist/test/agents/external-process.e2e.js
@@ -4,6 +4,7 @@ const test = require("tape");
 const fs_extra_1 = require("fs-extra");
 const path = require("path");
 const Errors = require("../../lib/errors");
+const Constants = require("../../lib/constants");
 const TestUtil = require("../util");
 const Fixtures = require("../fixtures");
 const types_1 = require("../../lib/types");
@@ -467,6 +468,29 @@ test("Support starting scout with a completely external core-agent", { skip: SKI
         }
         t.end(err);
     });
+});
+test("first start() waits for daemon startup, subsequent start() calls resolve instantly", { skip: SKIP_BINARY_TESTS }, t => {
+    let agent;
+    TestUtil.bootstrapExternalProcessAgent(t, TestConstants.TEST_APP_VERSION)
+        .then(a => agent = a)
+        // First start() — daemon not yet running, must wait DEFAULT_BIN_STARTUP_WAIT_MS
+        .then(() => {
+        const t0 = Date.now();
+        return agent.start().then(() => Date.now() - t0);
+    })
+        .then(elapsed => {
+        t.assert(elapsed >= Constants.DEFAULT_BIN_STARTUP_WAIT_MS, `first start() took ${elapsed}ms (expected >= ${Constants.DEFAULT_BIN_STARTUP_WAIT_MS}ms)`);
+    })
+        // Second start() — peerRunning() returns true, returns this immediately
+        .then(() => {
+        const t0 = Date.now();
+        return agent.start().then(() => Date.now() - t0);
+    })
+        .then(elapsed => {
+        t.assert(elapsed < Constants.DEFAULT_BIN_STARTUP_WAIT_MS, `second start() took ${elapsed}ms (expected < ${Constants.DEFAULT_BIN_STARTUP_WAIT_MS}ms)`);
+    })
+        .then(() => TestUtil.cleanup(t, agent))
+        .catch(err => TestUtil.cleanup(t, agent, err));
 });
 test("Timeout agent messages", { skip: SKIP_BINARY_TESTS }, t => {
     let agent;

--- a/dist/test/config.unit.js
+++ b/dist/test/config.unit.js
@@ -11,7 +11,7 @@ const TestConstants = require("./constants");
 const util_1 = require("./util");
 test("ScoutConfiguration builds with minimal passed ENV", t => {
     // This env mimics what would be passed in from process.env
-    const config = types_1.buildScoutConfiguration({}, {
+    const config = (0, types_1.buildScoutConfiguration)({}, {
         env: {
             SCOUT_NAME: "app",
             SCOUT_HOSTNAME: "hostname",
@@ -27,39 +27,39 @@ test("ScoutConfiguration builds with minimal passed ENV", t => {
 // // WARNING: This test must be run with some isolation or serially,
 // // since it touches process.env (even though it resets it)
 test("ScoutConfiguration overrides correctly for every config value", (t) => {
-    util_1.testConfigurationOverlay(t, { appKey: "name", envValue: "test", expectedValue: "test" });
-    util_1.testConfigurationOverlay(t, { appKey: "appServer", envValue: "test-server", expectedValue: "test-server" });
-    util_1.testConfigurationOverlay(t, {
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "name", envValue: "test", expectedValue: "test" });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "appServer", envValue: "test-server", expectedValue: "test-server" });
+    (0, util_1.testConfigurationOverlay)(t, {
         appKey: "applicationRoot",
         envValue: "/var/app/root",
         expectedValue: "/var/app/root"
     });
-    util_1.testConfigurationOverlay(t, { appKey: "coreAgentDir", envValue: "/tmp/dir", expectedValue: "/tmp/dir" });
-    util_1.testConfigurationOverlay(t, { appKey: "coreAgentDownload", envValue: "true", expectedValue: true });
-    util_1.testConfigurationOverlay(t, { appKey: "coreAgentLaunch", envValue: "false", expectedValue: false });
-    util_1.testConfigurationOverlay(t, { appKey: "coreAgentLogLevel", envValue: "info", expectedValue: types_1.LogLevel.Info });
-    util_1.testConfigurationOverlay(t, { appKey: "coreAgentPermissions", envValue: "700", expectedValue: 700 });
-    util_1.testConfigurationOverlay(t, { appKey: "coreAgentversion", envValue: "v1.2.4", expectedValue: "v1.2.4" });
-    util_1.testConfigurationOverlay(t, {
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "coreAgentDir", envValue: "/tmp/dir", expectedValue: "/tmp/dir" });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "coreAgentDownload", envValue: "true", expectedValue: true });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "coreAgentLaunch", envValue: "false", expectedValue: false });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "coreAgentLogLevel", envValue: "info", expectedValue: types_1.LogLevel.Info });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "coreAgentPermissions", envValue: "700", expectedValue: 700 });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "coreAgentversion", envValue: "v1.2.4", expectedValue: "v1.2.4" });
+    (0, util_1.testConfigurationOverlay)(t, {
         appKey: "disabledInstruments",
         envValue: "instrument_1,instrument_2",
         expectedValue: ["instrument_1", "instrument_2"],
     });
-    util_1.testConfigurationOverlay(t, { appKey: "downloadUrl", envValue: "example.org", expectedValue: "example.org" });
-    util_1.testConfigurationOverlay(t, { appKey: "framework", envValue: "fw_value", expectedValue: "fw_value" });
-    util_1.testConfigurationOverlay(t, { appKey: "frameworkversion", envValue: "v1", expectedValue: "v1" });
-    util_1.testConfigurationOverlay(t, { appKey: "hostname", envValue: "test-hostname", expectedValue: "test-hostname" });
-    util_1.testConfigurationOverlay(t, {
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "downloadUrl", envValue: "example.org", expectedValue: "example.org" });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "framework", envValue: "fw_value", expectedValue: "fw_value" });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "frameworkversion", envValue: "v1", expectedValue: "v1" });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "hostname", envValue: "test-hostname", expectedValue: "test-hostname" });
+    (0, util_1.testConfigurationOverlay)(t, {
         appKey: "ignore",
         envValue: "/api/v1/example,/api/v1/test",
         expectedValue: ["/api/v1/example", "/api/v1/test"],
     });
-    util_1.testConfigurationOverlay(t, { appKey: "key", envValue: "123456789", expectedValue: "123456789" });
-    util_1.testConfigurationOverlay(t, { appKey: "logLevel", envValue: "warn", expectedValue: types_1.LogLevel.Warn });
-    util_1.testConfigurationOverlay(t, { appKey: "monitor", envValue: "true", expectedValue: true });
-    util_1.testConfigurationOverlay(t, { appKey: "revisionSha", envValue: "51ab8123", expectedValue: "51ab8123" });
-    util_1.testConfigurationOverlay(t, { appKey: "scmSubdirectory", envValue: "/var/code", expectedValue: "/var/code" });
-    util_1.testConfigurationOverlay(t, {
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "key", envValue: "123456789", expectedValue: "123456789" });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "logLevel", envValue: "warn", expectedValue: types_1.LogLevel.Warn });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "monitor", envValue: "true", expectedValue: true });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "revisionSha", envValue: "51ab8123", expectedValue: "51ab8123" });
+    (0, util_1.testConfigurationOverlay)(t, { appKey: "scmSubdirectory", envValue: "/var/code", expectedValue: "/var/code" });
+    (0, util_1.testConfigurationOverlay)(t, {
         appKey: "socketPath",
         envValue: "/var/path/to/socket.sock",
         expectedValue: "/var/path/to/socket.sock",
@@ -79,7 +79,7 @@ test("application metadata is correctly generated", (t) => {
         SCOUT_APPLICATION_ROOT: "/var/app",
         SCOUT_REVISION_SHA: "12345678",
     };
-    const config = types_1.buildScoutConfiguration({}, { env });
+    const config = (0, types_1.buildScoutConfiguration)({}, { env });
     const appMetadata = new types_1.ApplicationMetadata(config);
     t.assert(appMetadata, "app metadata was generated");
     t.equals(appMetadata.language, "nodejs", `[language] matches [${appMetadata.language}]`);
@@ -102,47 +102,47 @@ test("application metadata is correctly generated", (t) => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/124
 test("core agent dir matches python (pre-TCP-by-default, v1.2.9)", (t) => {
-    const config = types_1.buildScoutConfiguration({
+    const config = (0, types_1.buildScoutConfiguration)({
         coreAgentVersion: "v1.2.9",
     });
     const scout = new scout_1.Scout(config);
     const expectedCoreAgentDir = path.join(os.tmpdir(), "scout_apm_core");
-    const expectedSocketPath = path.join(expectedCoreAgentDir, `scout_apm_core-v1.2.9-${types_1.generateTriple()}`, "core-agent.sock");
+    const expectedSocketPath = path.join(expectedCoreAgentDir, `scout_apm_core-v1.2.9-${(0, types_1.generateTriple)()}`, "core-agent.sock");
     t.equals(config.coreAgentDir, expectedCoreAgentDir, "core agent directory matches the expected value");
     t.equals(scout.getSocketPath(), `unix://${expectedSocketPath}`, "socket path matches expected value");
     t.end();
 });
 // https://github.com/scoutapp/scout_apm_node/issues/233
 test("core agent dir matches python (post-TCP v.1.3.0+)", (t) => {
-    const config = types_1.buildScoutConfiguration({ coreAgentVersion: TestConstants.TEST_APP_VERSION });
+    const config = (0, types_1.buildScoutConfiguration)({ coreAgentVersion: TestConstants.TEST_APP_VERSION });
     const scout = new scout_1.Scout(config);
     const expectedCoreAgentDir = path.join(os.tmpdir(), "scout_apm_core");
-    const expectedSocketPath = path.join(expectedCoreAgentDir, `scout_apm_core-${TestConstants.TEST_APP_VERSION}-${types_1.generateTriple()}`, "core-agent.sock");
+    const expectedSocketPath = path.join(expectedCoreAgentDir, `scout_apm_core-${TestConstants.TEST_APP_VERSION}-${(0, types_1.generateTriple)()}`, "core-agent.sock");
     t.equals(config.coreAgentDir, expectedCoreAgentDir, "core agent directory matches the expected value");
     t.equals(scout.getSocketPath(), `tcp://127.0.0.1:6590`, "TCP uri matches expected value");
     t.end();
 });
 // https://github.com/scoutapp/scout_apm_node/issues/169
 test("application root is present in default", (t) => {
-    const config = types_1.buildScoutConfiguration();
+    const config = (0, types_1.buildScoutConfiguration)();
     // Application root is supposed to be the folder *above* the project's folder
-    const expectedApplicationRoot = path.dirname(app_root_dir_1.get());
+    const expectedApplicationRoot = path.dirname((0, app_root_dir_1.get)());
     t.equals(config.applicationRoot, expectedApplicationRoot, `root dir matches expected [${expectedApplicationRoot}]`);
     t.end();
 });
 test("log level accepts both upper and lower case", (t) => {
     // Upper, lower, weird cases
-    t.equals(types_1.parseLogLevel("DEBUG"), types_1.LogLevel.Debug);
-    t.equals(types_1.parseLogLevel("debug"), types_1.LogLevel.Debug);
-    t.equals(types_1.parseLogLevel("DEbUG"), types_1.LogLevel.Debug);
-    t.equals(types_1.parseLogLevel("INFO"), types_1.LogLevel.Info);
-    t.equals(types_1.parseLogLevel("info"), types_1.LogLevel.Info);
-    t.equals(types_1.parseLogLevel("InfO"), types_1.LogLevel.Info);
-    t.equals(types_1.parseLogLevel("WARN"), types_1.LogLevel.Warn);
-    t.equals(types_1.parseLogLevel("warn"), types_1.LogLevel.Warn);
-    t.equals(types_1.parseLogLevel("wARn"), types_1.LogLevel.Warn);
-    t.equals(types_1.parseLogLevel("ERROR"), types_1.LogLevel.Error);
-    t.equals(types_1.parseLogLevel("error"), types_1.LogLevel.Error);
-    t.equals(types_1.parseLogLevel("Error"), types_1.LogLevel.Error);
+    t.equals((0, types_1.parseLogLevel)("DEBUG"), types_1.LogLevel.Debug);
+    t.equals((0, types_1.parseLogLevel)("debug"), types_1.LogLevel.Debug);
+    t.equals((0, types_1.parseLogLevel)("DEbUG"), types_1.LogLevel.Debug);
+    t.equals((0, types_1.parseLogLevel)("INFO"), types_1.LogLevel.Info);
+    t.equals((0, types_1.parseLogLevel)("info"), types_1.LogLevel.Info);
+    t.equals((0, types_1.parseLogLevel)("InfO"), types_1.LogLevel.Info);
+    t.equals((0, types_1.parseLogLevel)("WARN"), types_1.LogLevel.Warn);
+    t.equals((0, types_1.parseLogLevel)("warn"), types_1.LogLevel.Warn);
+    t.equals((0, types_1.parseLogLevel)("wARn"), types_1.LogLevel.Warn);
+    t.equals((0, types_1.parseLogLevel)("ERROR"), types_1.LogLevel.Error);
+    t.equals((0, types_1.parseLogLevel)("error"), types_1.LogLevel.Error);
+    t.equals((0, types_1.parseLogLevel)("Error"), types_1.LogLevel.Error);
     t.end();
 });

--- a/dist/test/constants.js
+++ b/dist/test/constants.js
@@ -1,4 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.TEST_APP_VERSION = exports.TEST_SCOUT_NAME = void 0;
 exports.TEST_SCOUT_NAME = "scout-e2e-tests";
 exports.TEST_APP_VERSION = "1.3.0";

--- a/dist/test/dashboard-send.ext.js
+++ b/dist/test/dashboard-send.ext.js
@@ -15,7 +15,7 @@ const request = require("supertest");
 const randomstring_1 = require("randomstring");
 const types_1 = require("../lib/types");
 const lib_1 = require("../lib");
-lib_1.setupRequireIntegrations(["pg", "ejs", "pug"]);
+(0, lib_1.setupRequireIntegrations)(["pg", "ejs", "pug"]);
 const scout_1 = require("../lib/scout");
 const express_1 = require("../lib/express");
 const TestUtil = require("./util");
@@ -30,8 +30,7 @@ const pug = require("pug");
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("Test scout app launch dashboard send", { timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS }, t => {
     // Build scout config & app meta for test
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -41,7 +40,7 @@ test("Test scout app launch dashboard send", { timeout: TestUtil.DASHBOARD_SEND_
     if (!config.name) {
         throw new Error("No Scout name! Provide one with the SCOUT_NAME ENV variable");
     }
-    const sha = randomstring_1.generate(64);
+    const sha = (0, randomstring_1.generate)(64);
     config.revisionSHA = sha;
     t.comment(`set revision sha to ${sha}`);
     // Generate generic app metadata
@@ -50,9 +49,9 @@ test("Test scout app launch dashboard send", { timeout: TestUtil.DASHBOARD_SEND_
     const scout = new scout_1.Scout(config, { appMeta });
     SCOUT_INSTANCES.push(scout);
     // Create a simple application and setup scout middleware
-    const app = TestUtil.simpleExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleExpressApp((0, express_1.scoutMiddleware)({
         scout,
-        requestTimeoutMs: 0,
+        requestTimeoutMs: 0, // disable request timeout to stop test from hanging
     }));
     // Set up a listener that should fire when the request is finished
     const listener = (data, another) => {
@@ -72,8 +71,7 @@ test("Test scout app launch dashboard send", { timeout: TestUtil.DASHBOARD_SEND_
 });
 // https://github.com/scoutapp/scout_apm_node/issues/71
 test("Scout sends basic controller span to dashboard", { timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS }, t => {
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -118,8 +116,7 @@ TestUtil.startContainerizedPostgresTest(test, cao => {
 // For the postgres integration
 // https://github.com/scoutapp/scout_apm_node/issues/83
 test("transaction with with postgres DB query to dashboard", { timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS }, t => {
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -181,8 +178,7 @@ test("transaction with with postgres DB query to dashboard", { timeout: TestUtil
 });
 // https://github.com/scoutapp/scout_apm_node/issues/140
 test("Many select statments and a render are in the right order", { timeout: TestUtil.PG_TEST_TIMEOUT_MS * 1000 }, t => {
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
     });
     const appMeta = new types_1.ApplicationMetadata(config, { frameworkVersion: "test" });
@@ -241,9 +237,9 @@ test("Many select statments and a render are in the right order", { timeout: Tes
         // Build the app with the postgres client
         .then(() => {
         // Create an application will do many queries and render something using ejs
-        app = TestUtil.queryAndRenderRandomNumbers(express_1.scoutMiddleware({
+        app = TestUtil.queryAndRenderRandomNumbers((0, express_1.scoutMiddleware)({
             scout,
-            requestTimeoutMs: 0,
+            requestTimeoutMs: 0, // disable request timeout to stop test from hanging
         }), "ejs", client);
     })
         // Perform the request to trigger the queries & render
@@ -273,8 +269,7 @@ TestUtil.startContainerizedMySQLTest(test, cao => {
 });
 test("transaction with mysql query to dashboard", { timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS }, t => {
     // Build scout config & app meta for test
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -335,8 +330,7 @@ test("transaction with mysql query to dashboard", { timeout: TestUtil.DASHBOARD_
 });
 test("transaction with mysql2 query to dashboard", { timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS }, t => {
     // Build scout config & app meta for test
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -403,8 +397,7 @@ TestUtil.stopContainerizedMySQLTest(test, () => MYSQL_CONTAINER_AND_OPTS);
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("Express pug integration dashboard send", { timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS }, t => {
     // Build scout config & app meta for test
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -417,9 +410,9 @@ test("Express pug integration dashboard send", { timeout: TestUtil.DASHBOARD_SEN
     const scout = new scout_1.Scout(config);
     SCOUT_INSTANCES.push(scout);
     // Create an application that's set up to use pug templating
-    const app = TestUtil.simpleHTML5BoilerplateApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleHTML5BoilerplateApp((0, express_1.scoutMiddleware)({
         scout,
-        requestTimeoutMs: 0,
+        requestTimeoutMs: 0, // disable request timeout to stop test from hanging
     }), "pug");
     // Set up a listener that should fire when the request is finished
     const listener = (data, another) => {

--- a/dist/test/express.e2e.js
+++ b/dist/test/express.e2e.js
@@ -13,7 +13,7 @@ const getNanoTime = require("nano-time");
 const BigNumber = require("big-number");
 const global_1 = require("../lib/global");
 const TEST_OPTS = { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS };
-lib_1.setupRequireIntegrations(["pug", "ejs", "mustache"]);
+(0, lib_1.setupRequireIntegrations)(["pug", "ejs", "mustache"]);
 // Shared mock agent for all express tests
 const sharedMock = new mock_agent_1.MockAgent();
 function withMock(extras = {}) {
@@ -28,9 +28,8 @@ test("setup: start shared mock agent", t => {
 });
 test("Simple operation", t => {
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleExpressApp(express_1.scoutMiddleware({
-        config: types_1.buildScoutConfiguration(withMock({
-            allowShutdown: true,
+    const app = TestUtil.simpleExpressApp((0, express_1.scoutMiddleware)({
+        config: (0, types_1.buildScoutConfiguration)(withMock({
             monitor: true,
         })),
         requestTimeoutMs: 0,
@@ -73,9 +72,8 @@ test("Simple operation", t => {
 });
 test("Dynamic segment routes (uses global instance)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
-        config: types_1.buildScoutConfiguration(withMock({
-            allowShutdown: true,
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
+        config: (0, types_1.buildScoutConfiguration)(withMock({
             monitor: true,
         })),
         requestTimeoutMs: 0,
@@ -131,9 +129,8 @@ test("Dynamic segment routes (uses global instance)", { timeout: TestUtil.EXPRES
 });
 test("Application which errors (uses global scout instance)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleErrorApp(express_1.scoutMiddleware({
-        config: types_1.buildScoutConfiguration(withMock({
-            allowShutdown: true,
+    const app = TestUtil.simpleErrorApp((0, express_1.scoutMiddleware)({
+        config: (0, types_1.buildScoutConfiguration)(withMock({
             monitor: true,
         })),
         requestTimeoutMs: 0,
@@ -157,13 +154,12 @@ test("Application which errors (uses global scout instance)", { timeout: TestUti
 });
 test("express ignores a path (exact path, with dynamic segments)", TEST_OPTS, t => {
     const path = "/dynamic/:segment";
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
         ignore: [path],
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -185,13 +181,12 @@ test("express ignores a path (exact path, with dynamic segments)", TEST_OPTS, t 
 });
 test("express ignores a path (exact path, static)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     const path = "/";
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
         ignore: [path],
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -214,13 +209,12 @@ test("express ignores a path (exact path, static)", { timeout: TestUtil.EXPRESS_
 test("express ignores a path (prefix, with dynamic segments)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     const path = "/dynamic/:segment";
     const prefix = "/dynamic";
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
         ignore: [prefix],
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -244,13 +238,12 @@ test("express ignores a path (prefix, with dynamic segments)", { timeout: TestUt
 test("express ignores a path (prefix, static)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     const path = "/echo-by-post";
     const prefix = "/echo";
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
         ignore: [prefix],
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -273,12 +266,11 @@ test("express ignores a path (prefix, static)", { timeout: TestUtil.EXPRESS_TEST
         .catch(err => TestUtil.shutdownScout(t, scout, err));
 });
 test("URI params are filtered", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -309,13 +301,12 @@ test("URI params are filtered", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t
         .catch(err => TestUtil.shutdownScout(t, scout, err));
 });
 test("URI filtered down to path", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
         uriReporting: types_1.URIReportingLevel.Path,
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -347,12 +338,11 @@ test("URI filtered down to path", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS },
 });
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("Pug integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     // Create an application that's set up to use pug templating
-    const app = TestUtil.simpleHTML5BoilerplateApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleHTML5BoilerplateApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -394,12 +384,11 @@ test("Pug integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t =
 });
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("ejs integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     // Create an application that's set up to use ejs templating
-    const app = TestUtil.simpleHTML5BoilerplateApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleHTML5BoilerplateApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -441,12 +430,11 @@ test("ejs integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t =
 });
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("mustache integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     // Create an application that's set up to use mustache templating
-    const app = TestUtil.simpleHTML5BoilerplateApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleHTML5BoilerplateApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -488,12 +476,11 @@ test("mustache integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }
 });
 // https://github.com/scoutapp/scout_apm_node/issues/129
 test("Nested spans on the top level controller have parent ID specified", TEST_OPTS, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     // Create an application that's set up to do a simple instrumentation
-    const app = TestUtil.simpleInstrumentApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleInstrumentApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -535,12 +522,11 @@ test("Nested spans on the top level controller have parent ID specified", TEST_O
 });
 // https://github.com/scoutapp/scout_apm_node/issues/150
 test("Unknown routes should not be recorded", TEST_OPTS, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     // Create an application that's set up to do a simple instrumentation
-    const app = TestUtil.simpleExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -567,12 +553,11 @@ test("Unknown routes should not be recorded", TEST_OPTS, t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/68
 test("Request queue time should be recorded", TEST_OPTS, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     // Create an application that's set up to do a simple instrumentation
-    const app = TestUtil.simpleExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -610,7 +595,7 @@ test("Request queue time should be recorded", TEST_OPTS, t => {
 });
 // Cleanup the global isntance(s) that get created
 test("Shutdown the global instance", t => {
-    const inst = global_1.getActiveGlobalScoutInstance();
+    const inst = (0, global_1.getActiveGlobalScoutInstance)();
     if (inst) {
         return TestUtil.shutdownScout(t, inst);
     }

--- a/dist/test/fixtures/index.js
+++ b/dist/test/fixtures/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.MUSTACHE_TEMPLATES = exports.SQL_QUERIES = exports.RESPONSES = exports.APP_META = exports.FILE_PATHS = void 0;
 const PATHS = require("./paths");
 exports.FILE_PATHS = PATHS;
 exports.APP_META = {

--- a/dist/test/fixtures/paths.js
+++ b/dist/test/fixtures/paths.js
@@ -1,8 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.EXPRESS_APP_WITH_SCOUT_PATH = exports.EXPRESS_APP_PATH = exports.EJS_HTML5_BOILERPLATE = exports.PUG_HTML5_BOILERPLATE = void 0;
 const path = require("path");
 const app_root_dir_1 = require("app-root-dir");
-exports.PUG_HTML5_BOILERPLATE = path.resolve(path.join(app_root_dir_1.get(), "test/fixtures/files/html5-boilerplate.pug"));
-exports.EJS_HTML5_BOILERPLATE = path.resolve(path.join(app_root_dir_1.get(), "test/fixtures/files/html5-boilerplate.ejs"));
-exports.EXPRESS_APP_PATH = path.resolve(path.join(app_root_dir_1.get(), "test/fixtures/applications/express-app.js"));
-exports.EXPRESS_APP_WITH_SCOUT_PATH = path.resolve(path.join(app_root_dir_1.get(), "test/fixtures/applications/express-app-with-scout.js"));
+exports.PUG_HTML5_BOILERPLATE = path.resolve(path.join((0, app_root_dir_1.get)(), "test/fixtures/files/html5-boilerplate.pug"));
+exports.EJS_HTML5_BOILERPLATE = path.resolve(path.join((0, app_root_dir_1.get)(), "test/fixtures/files/html5-boilerplate.ejs"));
+exports.EXPRESS_APP_PATH = path.resolve(path.join((0, app_root_dir_1.get)(), "test/fixtures/applications/express-app.js"));
+exports.EXPRESS_APP_WITH_SCOUT_PATH = path.resolve(path.join((0, app_root_dir_1.get)(), "test/fixtures/applications/express-app-with-scout.js"));

--- a/dist/test/integration/express.int.js
+++ b/dist/test/integration/express.int.js
@@ -8,10 +8,10 @@ const lib_1 = require("../../lib");
 const types_1 = require("../../lib/types");
 const scout_1 = require("../../lib/scout");
 const TestUtil = require("../util");
-lib_1.setupRequireIntegrations(["pug", "ejs", "mustache"]);
+(0, lib_1.setupRequireIntegrations)(["pug", "ejs", "mustache"]);
 const TIMEOUT = 15000;
 function buildScoutWithMock(mock, extra) {
-    return types_1.buildScoutConfiguration(Object.assign({ allowShutdown: true, monitor: true, coreAgentDownload: false, coreAgentLaunch: false, socketPath: mock.socketPath() }, extra));
+    return (0, types_1.buildScoutConfiguration)(Object.assign({ monitor: true, coreAgentDownload: false, coreAgentLaunch: false, socketPath: mock.socketPath() }, extra));
 }
 function nextRequestSent(scout) {
     return new Promise((resolve, reject) => {
@@ -31,7 +31,7 @@ function nextRequestSent(scout) {
     });
 }
 function makeApp(scout, factory) {
-    return factory(express_1.scoutMiddleware({
+    return factory((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -80,11 +80,10 @@ test("Express dynamic route captures route pattern", { timeout: TIMEOUT }, (t) =
         return sentPromise;
     })
         .then((data) => {
-        var _a;
         const spans = data.request.getChildSpansSync();
         const controllerSpan = spans.find((s) => s.operation.startsWith("Controller/"));
         t.ok(controllerSpan, "Controller span present for dynamic route");
-        t.ok(controllerSpan && controllerSpan.operation.includes(":segment"), `Route pattern captured — operation: ${(_a = controllerSpan) === null || _a === void 0 ? void 0 : _a.operation}`);
+        t.ok(controllerSpan && controllerSpan.operation.includes(":segment"), `Route pattern captured — operation: ${controllerSpan === null || controllerSpan === void 0 ? void 0 : controllerSpan.operation}`);
         return TestUtil.shutdownScout(t, scout);
     })
         .then(() => mock.stop())

--- a/dist/test/integration/libraries.int.js
+++ b/dist/test/integration/libraries.int.js
@@ -11,14 +11,13 @@ const lib_1 = require("../../lib");
 const types_1 = require("../../lib/types");
 const scout_1 = require("../../lib/scout");
 // Must run before any instrumented library is first required so RITM can shim them.
-lib_1.setupRequireIntegrations(["mustache", "ejs", "pug", "pg"]);
+(0, lib_1.setupRequireIntegrations)(["mustache", "ejs", "pug", "pg"]);
 const TIMEOUT = 15000;
 const PAYLOAD_DIR = path.join(__dirname, "payloads");
 // Fixture views live in source tree; use getRootDir() so the path is correct at runtime.
-const VIEWS_DIR = path.join(app_root_dir_1.get(), "test/fixtures/files");
+const VIEWS_DIR = path.join((0, app_root_dir_1.get)(), "test/fixtures/files");
 function buildConfig(mock) {
-    return types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    return (0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -26,7 +25,7 @@ function buildConfig(mock) {
     });
 }
 function makeApp(scout, factory) {
-    return factory(express_1.scoutMiddleware({
+    return factory((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,

--- a/dist/test/integration/mock-agent.js
+++ b/dist/test/integration/mock-agent.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.MockAgent = void 0;
 const fs = require("fs");
 const net = require("net");
 const path = require("path");

--- a/dist/test/integration/nest.int.js
+++ b/dist/test/integration/nest.int.js
@@ -18,40 +18,40 @@ let TestController = class TestController {
     dynamic() { return { status: "ok" }; }
 };
 tslib_1.__decorate([
-    common_1.Get("/"),
+    (0, common_1.Get)("/"),
     tslib_1.__metadata("design:type", Function),
     tslib_1.__metadata("design:paramtypes", []),
     tslib_1.__metadata("design:returntype", void 0)
 ], TestController.prototype, "home", null);
 tslib_1.__decorate([
-    common_1.Get("/dynamic/:segment"),
+    (0, common_1.Get)("/dynamic/:segment"),
     tslib_1.__metadata("design:type", Function),
     tslib_1.__metadata("design:paramtypes", []),
     tslib_1.__metadata("design:returntype", void 0)
 ], TestController.prototype, "dynamic", null);
 TestController = tslib_1.__decorate([
-    common_1.Controller()
+    (0, common_1.Controller)()
 ], TestController);
 let ApiController = class ApiController {
     hello() { return { message: "hello" }; }
 };
 tslib_1.__decorate([
-    common_1.Get("hello"),
+    (0, common_1.Get)("hello"),
     tslib_1.__metadata("design:type", Function),
     tslib_1.__metadata("design:paramtypes", []),
     tslib_1.__metadata("design:returntype", void 0)
 ], ApiController.prototype, "hello", null);
 ApiController = tslib_1.__decorate([
-    common_1.Controller("api")
+    (0, common_1.Controller)("api")
 ], ApiController);
 let TestModule = class TestModule {
 };
 TestModule = tslib_1.__decorate([
-    common_1.Module({ controllers: [TestController, ApiController] })
+    (0, common_1.Module)({ controllers: [TestController, ApiController] })
 ], TestModule);
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function buildConfig(mock, extra) {
-    return types_1.buildScoutConfiguration(Object.assign({ allowShutdown: true, monitor: true, coreAgentDownload: false, coreAgentLaunch: false, socketPath: mock.socketPath() }, extra));
+    return (0, types_1.buildScoutConfiguration)(Object.assign({ monitor: true, coreAgentDownload: false, coreAgentLaunch: false, socketPath: mock.socketPath() }, extra));
 }
 function nextRequestSent(scout) {
     return new Promise((resolve, reject) => {
@@ -73,7 +73,7 @@ function nextRequestSent(scout) {
 function makeNestApp(scout) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
         const app = yield core_1.NestFactory.create(TestModule, { logger: false });
-        app.use(nest_1.nestMiddleware({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+        app.use((0, nest_1.nestMiddleware)({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
         yield app.init();
         return app;
     });
@@ -95,20 +95,18 @@ test("NestJS GET / creates a Controller/GET span", { timeout: TIMEOUT }, (t) => 
         return sentPromise;
     })
         .then((data) => {
-        var _a, _b;
         const spans = data.request.getChildSpansSync();
         const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
         t.ok(ctrl, "Controller span created");
-        t.ok((_a = ctrl) === null || _a === void 0 ? void 0 : _a.operation.includes("GET"), "span includes GET");
-        t.equal((_b = ctrl) === null || _b === void 0 ? void 0 : _b.operation, "Controller/GET /", "route path is /");
+        t.ok(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation.includes("GET"), "span includes GET");
+        t.equal(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation, "Controller/GET /", "route path is /");
     })
         .then(() => nestApp.close())
         .then(() => TestUtil.shutdownScout(t, scout))
         .then(() => mock.stop())
         .catch((err) => {
-        var _a;
         mock.stop().catch(() => undefined);
-        (_a = nestApp) === null || _a === void 0 ? void 0 : _a.close().catch(() => undefined);
+        nestApp === null || nestApp === void 0 ? void 0 : nestApp.close().catch(() => undefined);
         t.fail(err.message);
         t.end();
     });
@@ -129,20 +127,18 @@ test("NestJS dynamic route captures route pattern not concrete value", { timeout
         return sentPromise;
     })
         .then((data) => {
-        var _a, _b, _c;
         const spans = data.request.getChildSpansSync();
         const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
         t.ok(ctrl, "Controller span created for dynamic route");
-        t.ok((_a = ctrl) === null || _a === void 0 ? void 0 : _a.operation.includes(":segment"), `route pattern captured, got: ${(_b = ctrl) === null || _b === void 0 ? void 0 : _b.operation}`);
-        t.notOk((_c = ctrl) === null || _c === void 0 ? void 0 : _c.operation.includes("hello-world"), "concrete value not in span operation");
+        t.ok(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation.includes(":segment"), `route pattern captured, got: ${ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation}`);
+        t.notOk(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation.includes("hello-world"), "concrete value not in span operation");
     })
         .then(() => nestApp.close())
         .then(() => TestUtil.shutdownScout(t, scout))
         .then(() => mock.stop())
         .catch((err) => {
-        var _a;
         mock.stop().catch(() => undefined);
-        (_a = nestApp) === null || _a === void 0 ? void 0 : _a.close().catch(() => undefined);
+        nestApp === null || nestApp === void 0 ? void 0 : nestApp.close().catch(() => undefined);
         t.fail(err.message);
         t.end();
     });
@@ -163,19 +159,17 @@ test("NestJS controller prefix is included in span operation", { timeout: TIMEOU
         return sentPromise;
     })
         .then((data) => {
-        var _a;
         const spans = data.request.getChildSpansSync();
         const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
         t.ok(ctrl, "Controller span created for prefixed route");
-        t.equal((_a = ctrl) === null || _a === void 0 ? void 0 : _a.operation, "Controller/GET /api/hello", "full path with prefix captured");
+        t.equal(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation, "Controller/GET /api/hello", "full path with prefix captured");
     })
         .then(() => nestApp.close())
         .then(() => TestUtil.shutdownScout(t, scout))
         .then(() => mock.stop())
         .catch((err) => {
-        var _a;
         mock.stop().catch(() => undefined);
-        (_a = nestApp) === null || _a === void 0 ? void 0 : _a.close().catch(() => undefined);
+        nestApp === null || nestApp === void 0 ? void 0 : nestApp.close().catch(() => undefined);
         t.fail(err.message);
         t.end();
     });
@@ -200,9 +194,8 @@ test("NestJS mock agent receives Register message on connect", { timeout: TIMEOU
         .then(() => mock.stop())
         .then(() => t.end())
         .catch((err) => {
-        var _a;
         mock.stop().catch(() => undefined);
-        (_a = nestApp) === null || _a === void 0 ? void 0 : _a.close().catch(() => undefined);
+        nestApp === null || nestApp === void 0 ? void 0 : nestApp.close().catch(() => undefined);
         t.fail(err.message);
         t.end();
     });

--- a/dist/test/integrations/ejs.e2e.js
+++ b/dist/test/integrations/ejs.e2e.js
@@ -10,16 +10,15 @@ const types_2 = require("../../lib/types");
 const fixtures_1 = require("../fixtures");
 // The hook for ejs has to be triggered this way in a typescript context
 // since a partial import from scout itself (lib/index) will not run the setupRequireIntegrations() code
-lib_1.setupRequireIntegrations(["ejs"]);
+(0, lib_1.setupRequireIntegrations)(["ejs"]);
 // ejs needs to be imported this way to trigger the require integration
 const ejs = require("ejs");
 test("the shim works", t => {
-    t.assert(integrations_1.getIntegrationSymbol() in ejs, "ejs export has the integration symbol");
+    t.assert((0, integrations_1.getIntegrationSymbol)() in ejs, "ejs export has the integration symbol");
     t.end();
 });
 test("ejs rendering a string is captured", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Set up a listener for the scout request that will contain the DB record
@@ -56,8 +55,7 @@ test("ejs rendering a string is captured", t => {
         .catch(err => TestUtil.shutdownScout(t, scout, err));
 });
 test("ejs rendering a file is captured", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Set up a listener for the scout request that will contain the DB record

--- a/dist/test/integrations/express.e2e.js
+++ b/dist/test/integrations/express.e2e.js
@@ -9,14 +9,14 @@ const scout_1 = require("../../lib/scout");
 // The hook for http has to be triggered this way in a typescript context
 // since a partial import from scout itself (lib/index) will not run the setupRequireIntegrations() code
 // *NOTE* this must be here since express is used from TestUtil
-lib_1.setupRequireIntegrations(["express"]);
+(0, lib_1.setupRequireIntegrations)(["express"]);
 const TestUtil = require("../util");
 const integrations_1 = require("../../lib/types/integrations");
 const express_1 = require("../../lib/integrations/express");
 const express_2 = require("../../lib/express");
 const types_2 = require("../../lib/types");
 test("the shim works", t => {
-    t.assert(integrations_1.getIntegrationSymbol() in require("express"), "express export has the integration symbol");
+    t.assert((0, integrations_1.getIntegrationSymbol)() in require("express"), "express export has the integration symbol");
     t.end();
 });
 test("express object still has native props", t => {
@@ -26,14 +26,13 @@ test("express object still has native props", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/127
 test("errors in controller functions trigger context updates", t => {
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
     });
     const scout = new scout_1.Scout(config);
-    const app = TestUtil.appWithGETSynchronousError(express_2.scoutMiddleware({
+    const app = TestUtil.appWithGETSynchronousError((0, express_2.scoutMiddleware)({
         scout,
-        requestTimeoutMs: 0,
+        requestTimeoutMs: 0, // disable request timeout to stop test from hanging
     }), (fn) => express_1.default.shimExpressFn(fn));
     // Set up a listener for the scout request that will be after the controller error is thrown
     // Express should catch the error (https://expressjs.com/en/guide/error-handling.html)
@@ -64,17 +63,16 @@ test("errors in controller functions trigger context updates", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/238
 test("express Routers are recorded (one level)", t => {
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
     });
     const scout = new scout_1.Scout(config);
-    const app = TestUtil.appWithRouterGET(express_2.scoutMiddleware({
+    const app = TestUtil.appWithRouterGET((0, express_2.scoutMiddleware)({
         scout,
-        requestTimeoutMs: 0,
+        requestTimeoutMs: 0, // disable request timeout to stop test from hanging
     }), (fn) => express_1.default.shimExpressFn(fn));
     // Create a name to use the echo router
-    const reqName = randomstring_1.generate(5);
+    const reqName = (0, randomstring_1.generate)(5);
     // Set up a listener for the scout request that will be after the Router-hosted GET is hit
     const listener = (data) => {
         if (!data || !data.request) {
@@ -118,17 +116,16 @@ test("express Routers are recorded (one level)", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/238
 test("express Routers are recorded (two levels)", t => {
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
     });
     const scout = new scout_1.Scout(config);
-    const app = TestUtil.appWithRouterGET(express_2.scoutMiddleware({
+    const app = TestUtil.appWithRouterGET((0, express_2.scoutMiddleware)({
         scout,
-        requestTimeoutMs: 0,
+        requestTimeoutMs: 0, // disable request timeout to stop test from hanging
     }), (fn) => express_1.default.shimExpressFn(fn));
     // Create a name to use the echo router
-    const reqName = randomstring_1.generate(5);
+    const reqName = (0, randomstring_1.generate)(5);
     // Set up a listener for the scout request that will be after the Router-hosted GET is hit
     const listener = (data) => {
         if (!data || !data.request) {

--- a/dist/test/integrations/fetch.e2e.js
+++ b/dist/test/integrations/fetch.e2e.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const lib_1 = require("../../lib");
-lib_1.setupRequireIntegrations(["fetch"]);
+(0, lib_1.setupRequireIntegrations)(["fetch"]);
 const http = require("http");
 const test = require("tape");
 const TestUtil = require("../util");
@@ -36,8 +36,7 @@ if (NODE_MAJOR < 18) {
 }
 else {
     test("HTTP/GET span is created for a fetch request", { timeout: TIMEOUT_MS }, (t) => {
-        const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-            allowShutdown: true,
+        const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
             monitor: true,
             coreAgentDownload: false,
             coreAgentLaunch: false,
@@ -64,8 +63,7 @@ else {
             .catch((err) => TestUtil.shutdownScout(t, scout, err));
     });
     test("HTTP/POST span is created for a fetch POST request", { timeout: TIMEOUT_MS }, (t) => {
-        const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-            allowShutdown: true,
+        const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
             monitor: true,
             coreAgentDownload: false,
             coreAgentLaunch: false,
@@ -93,8 +91,7 @@ else {
             .catch((err) => TestUtil.shutdownScout(t, scout, err));
     });
     test("HTTP/GET span has error context on network failure", { timeout: TIMEOUT_MS }, (t) => {
-        const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-            allowShutdown: true,
+        const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
             monitor: true,
             coreAgentDownload: false,
             coreAgentLaunch: false,
@@ -122,8 +119,7 @@ else {
             .catch((err) => TestUtil.shutdownScout(t, scout, err));
     });
     test("concurrent fetch requests each get their own span", { timeout: TIMEOUT_MS }, (t) => {
-        const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-            allowShutdown: true,
+        const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
             monitor: true,
             coreAgentDownload: false,
             coreAgentLaunch: false,

--- a/dist/test/integrations/http.e2e.js
+++ b/dist/test/integrations/http.e2e.js
@@ -11,22 +11,21 @@ const express_1 = require("../../lib/express");
 const types_2 = require("../../lib/types");
 // The hook for http has to be triggered this way in a typescript context
 // since a partial import from scout itself (lib/index) will not run the setupRequireIntegrations() code
-lib_1.setupRequireIntegrations(["http"]);
+(0, lib_1.setupRequireIntegrations)(["http"]);
 // http needs to be imported this way to trigger the require integration
 const http = require("http");
 test("the shim works", t => {
-    t.assert(integrations_1.getIntegrationSymbol() in http, "http export has the integration symbol");
+    t.assert((0, integrations_1.getIntegrationSymbol)() in http, "http export has the integration symbol");
     t.end();
 });
 test("http connections are captured", t => {
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
     });
     const scout = new scout_1.Scout(config);
-    const app = TestUtil.simpleExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleExpressApp((0, express_1.scoutMiddleware)({
         scout,
-        requestTimeoutMs: 0,
+        requestTimeoutMs: 0, // disable request timeout to stop test from hanging
     }));
     let expectedReqId;
     // Set up a listener for the scout request that will contain the DB record

--- a/dist/test/integrations/https.e2e.js
+++ b/dist/test/integrations/https.e2e.js
@@ -11,15 +11,14 @@ const express_1 = require("../../lib/express");
 const types_2 = require("../../lib/types");
 // The hook for https has to be triggered this way in a typescript context
 // since a partial import from scout itself (lib/index) will not run the setupRequireIntegrations() code
-lib_1.setupRequireIntegrations(["https"]);
+(0, lib_1.setupRequireIntegrations)(["https"]);
 const https = require("https");
 test("the shim works", t => {
-    t.assert(integrations_1.getIntegrationSymbol() in https, "https export has the integration symbol");
+    t.assert((0, integrations_1.getIntegrationSymbol)() in https, "https export has the integration symbol");
     t.end();
 });
 test("https.get triggers proper span creation", t => {
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
     });
     const scout = new scout_1.Scout(config);
@@ -71,8 +70,7 @@ test("https.get triggers proper span creation", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/209
 test("An endpoint using http-proxy-middleware should capture proxied requests", t => {
-    const config = types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)({
         monitor: true,
     });
     const scout = new scout_1.Scout(config);
@@ -80,7 +78,7 @@ test("An endpoint using http-proxy-middleware should capture proxied requests", 
     const proxyTarget = "https://www.scoutapm.com";
     const app = TestUtil.appWithHTTPProxyMiddleware(
     // we disable request timeout to stop test from hanging
-    express_1.scoutMiddleware({ scout, requestTimeoutMs: 0 }), proxyTarget);
+    (0, express_1.scoutMiddleware)({ scout, requestTimeoutMs: 0 }), proxyTarget);
     let expectedReqId;
     // Set up a listener for the scout request that will contain the DB record
     const listener = (data) => {

--- a/dist/test/integrations/ioredis.e2e.js
+++ b/dist/test/integrations/ioredis.e2e.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const lib_1 = require("../../lib");
-lib_1.setupRequireIntegrations(["ioredis"]);
+(0, lib_1.setupRequireIntegrations)(["ioredis"]);
 const ioredis_1 = require("ioredis");
 const test = require("tape");
 const TestUtil = require("../util");
@@ -17,12 +17,11 @@ test("setup: start shared mock agent", (t) => {
     sharedMock.start().then(() => t.end()).catch(t.end);
 });
 test("ioredis shim is applied", (t) => {
-    t.ok(ioredis_1.default[integrations_1.getIntegrationSymbol()], "Redis class has integration symbol");
+    t.ok(ioredis_1.default[(0, integrations_1.getIntegrationSymbol)()], "Redis class has integration symbol");
     t.end();
 });
 test("Redis/SET span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -55,8 +54,7 @@ test("Redis/SET span is created during a request", { timeout: TIMEOUT_MS }, (t) 
     });
 });
 test("Redis/GET span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/dist/test/integrations/mongodb.e2e.js
+++ b/dist/test/integrations/mongodb.e2e.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const lib_1 = require("../../lib");
-lib_1.setupRequireIntegrations(["mongodb"]);
+(0, lib_1.setupRequireIntegrations)(["mongodb"]);
 const mongodb_1 = require("mongodb");
 const test = require("tape");
 const TestUtil = require("../util");
@@ -19,12 +19,11 @@ test("setup: start shared mock agent", (t) => {
 });
 test("mongodb shim is applied", (t) => {
     const mongoModule = require("mongodb");
-    t.ok(mongoModule[integrations_1.getIntegrationSymbol()], "mongodb module has integration symbol");
+    t.ok(mongoModule[(0, integrations_1.getIntegrationSymbol)()], "mongodb module has integration symbol");
     t.end();
 });
 test("MongoDB/insertOne span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -60,8 +59,7 @@ test("MongoDB/insertOne span is created during a request", { timeout: TIMEOUT_MS
     });
 });
 test("MongoDB/find span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -96,8 +94,7 @@ test("MongoDB/find span is created during a request", { timeout: TIMEOUT_MS }, (
     });
 });
 test("MongoDB span has error context on command failure", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/dist/test/integrations/mustache.e2e.js
+++ b/dist/test/integrations/mustache.e2e.js
@@ -10,16 +10,15 @@ const fixtures_1 = require("../fixtures");
 const Mustache = require("mustache");
 // The hook for mustache has to be triggered this way in a typescript context
 // since a partial import from scout itself (lib/index) will not run the setupRequireIntegrations() code
-lib_1.setupRequireIntegrations(["mustache"]);
+(0, lib_1.setupRequireIntegrations)(["mustache"]);
 // mustache needs to be imported this way to trigger the require integration
 const mustache = require("mustache");
 test("the shim works", t => {
-    t.assert(integrations_1.getIntegrationSymbol() in mustache, "mustache export has the integration symbol");
+    t.assert((0, integrations_1.getIntegrationSymbol)() in mustache, "mustache export has the integration symbol");
     t.end();
 });
 test("mustache rendering a string is captured", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     const simple = fixtures_1.MUSTACHE_TEMPLATES.HELLO_WORLD;

--- a/dist/test/integrations/mysql.e2e.js
+++ b/dist/test/integrations/mysql.e2e.js
@@ -10,14 +10,14 @@ const types_2 = require("../../lib/types");
 const fixtures_1 = require("../fixtures");
 // The hook for MYSQL has to be triggered this way in a typescript context
 // since a partial import like { Client } will not trigger a require
-lib_1.setupRequireIntegrations(["mysql"]);
+(0, lib_1.setupRequireIntegrations)(["mysql"]);
 const mysql_1 = require("mysql");
 let MYSQL_CONTAINER_AND_OPTS = null;
 // NOTE: this test *presumes* that the integration is working, since the integration is require-based
 // it may break if import order is changed (require hook would not have taken place)
 test("the shim works", t => {
-    const connection = mysql_1.createConnection({ host: "localhost", user: "mysql", password: "mysql" });
-    t.assert(integrations_1.getIntegrationSymbol() in connection, "created connection has the integration symbol");
+    const connection = (0, mysql_1.createConnection)({ host: "localhost", user: "mysql", password: "mysql" });
+    t.assert((0, integrations_1.getIntegrationSymbol)() in connection, "created connection has the integration symbol");
     t.end();
 });
 // Pseudo test that will start a containerized mysql instance
@@ -25,8 +25,7 @@ TestUtil.startContainerizedMySQLTest(test, cao => {
     MYSQL_CONTAINER_AND_OPTS = cao;
 });
 test("SELECT query during a request is recorded", { timeout: TestUtil.MYSQL_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Setup a MYSQL Connection that we'll use later

--- a/dist/test/integrations/mysql2.e2e.js
+++ b/dist/test/integrations/mysql2.e2e.js
@@ -10,7 +10,7 @@ const types_2 = require("../../lib/types");
 const fixtures_1 = require("../fixtures");
 // The hook for mysql2 has to be triggered this way in a typescript context
 // since a partial import from scout itself (lib/index) will not run the setupRequireIntegrations() code
-lib_1.setupRequireIntegrations([
+(0, lib_1.setupRequireIntegrations)([
     "mysql2",
 ]);
 // The hook for MYSQL2 has to be triggered this way in a typescript context
@@ -23,14 +23,13 @@ TestUtil.startContainerizedMySQLTest(test, cao => { MYSQL2_CONTAINER_AND_OPTS = 
 test("the shim works", t => {
     TestUtil.makeConnectedMySQL2Connection(() => MYSQL2_CONTAINER_AND_OPTS)
         .then(conn => {
-        t.assert(integrations_1.getIntegrationSymbol() in conn, "created connection has the integration symbol");
+        t.assert((0, integrations_1.getIntegrationSymbol)() in conn, "created connection has the integration symbol");
     })
         .then(() => t.end())
         .catch(err => t.end(err));
 });
 test("SELECT query during a request is recorded", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Setup a MYSQL2 Connection that we'll use later

--- a/dist/test/integrations/nest.e2e.js
+++ b/dist/test/integrations/nest.e2e.js
@@ -11,7 +11,7 @@ const types_1 = require("../../lib/types");
 const scout_1 = require("../../lib/scout");
 const nest_1 = require("../../lib/nest");
 const TestUtil = require("../util");
-lib_1.setupRequireIntegrations(["mustache", "http"]);
+(0, lib_1.setupRequireIntegrations)(["mustache", "http"]);
 const TIMEOUT = 15000;
 // ── Shared test controllers ───────────────────────────────────────────────────
 let BasicController = class BasicController {
@@ -19,24 +19,24 @@ let BasicController = class BasicController {
     item() { return { status: "ok" }; }
 };
 tslib_1.__decorate([
-    common_1.Get("/"),
+    (0, common_1.Get)("/"),
     tslib_1.__metadata("design:type", Function),
     tslib_1.__metadata("design:paramtypes", []),
     tslib_1.__metadata("design:returntype", void 0)
 ], BasicController.prototype, "home", null);
 tslib_1.__decorate([
-    common_1.Get("/items/:id"),
+    (0, common_1.Get)("/items/:id"),
     tslib_1.__metadata("design:type", Function),
     tslib_1.__metadata("design:paramtypes", []),
     tslib_1.__metadata("design:returntype", void 0)
 ], BasicController.prototype, "item", null);
 BasicController = tslib_1.__decorate([
-    common_1.Controller()
+    (0, common_1.Controller)()
 ], BasicController);
 let BasicModule = class BasicModule {
 };
 BasicModule = tslib_1.__decorate([
-    common_1.Module({ controllers: [BasicController] })
+    (0, common_1.Module)({ controllers: [BasicController] })
 ], BasicModule);
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function nextRequestSent(scout, skipCount = 0) {
@@ -64,17 +64,17 @@ function nextRequestSent(scout, skipCount = 0) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 test("nestMiddleware is a function", (t) => {
     t.equal(typeof nest_1.nestMiddleware, "function", "nestMiddleware is exported");
-    t.equal(typeof nest_1.nestMiddleware(), "function", "nestMiddleware() returns a middleware function");
+    t.equal(typeof (0, nest_1.nestMiddleware)(), "function", "nestMiddleware() returns a middleware function");
     t.end();
 });
 test("NestJS app instruments root route", { timeout: TIMEOUT }, (t) => {
-    const config = types_1.buildScoutConfiguration({ allowShutdown: true, monitor: true });
+    const config = (0, types_1.buildScoutConfiguration)({ monitor: true });
     const scout = new scout_1.Scout(config);
     let nestApp;
     core_1.NestFactory.create(BasicModule, { logger: false })
         .then((app) => {
         nestApp = app;
-        app.use(nest_1.nestMiddleware({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+        app.use((0, nest_1.nestMiddleware)({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
         return app.init();
     })
         .then(() => request(nestApp.getHttpServer()).get("/").expect(200))
@@ -84,28 +84,26 @@ test("NestJS app instruments root route", { timeout: TIMEOUT }, (t) => {
         return sentPromise;
     })
         .then((data) => {
-        var _a;
         const spans = data.request.getChildSpansSync();
         const ctrl = spans.find((s) => s.operation.startsWith("Controller/GET"));
         t.ok(ctrl, "Controller/GET span present");
-        t.equal((_a = ctrl) === null || _a === void 0 ? void 0 : _a.operation, "Controller/GET /", "operation is Controller/GET /");
+        t.equal(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation, "Controller/GET /", "operation is Controller/GET /");
     })
         .then(() => nestApp.close())
         .then(() => TestUtil.shutdownScout(t, scout))
         .catch((err) => {
-        var _a;
-        (_a = nestApp) === null || _a === void 0 ? void 0 : _a.close().catch(() => undefined);
+        nestApp === null || nestApp === void 0 ? void 0 : nestApp.close().catch(() => undefined);
         TestUtil.shutdownScout(t, scout, err);
     });
 });
 test("NestJS parameterised route captures pattern not value", { timeout: TIMEOUT }, (t) => {
-    const config = types_1.buildScoutConfiguration({ allowShutdown: true, monitor: true });
+    const config = (0, types_1.buildScoutConfiguration)({ monitor: true });
     const scout = new scout_1.Scout(config);
     let nestApp;
     core_1.NestFactory.create(BasicModule, { logger: false })
         .then((app) => {
         nestApp = app;
-        app.use(nest_1.nestMiddleware({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+        app.use((0, nest_1.nestMiddleware)({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
         return app.init();
     })
         .then(() => request(nestApp.getHttpServer()).get("/").expect(200))
@@ -115,18 +113,16 @@ test("NestJS parameterised route captures pattern not value", { timeout: TIMEOUT
         return sentPromise;
     })
         .then((data) => {
-        var _a, _b, _c;
         const spans = data.request.getChildSpansSync();
         const ctrl = spans.find((s) => s.operation.startsWith("Controller/GET"));
         t.ok(ctrl, "Controller span created");
-        t.ok((_a = ctrl) === null || _a === void 0 ? void 0 : _a.operation.includes(":id"), `includes :id pattern — got ${(_b = ctrl) === null || _b === void 0 ? void 0 : _b.operation}`);
-        t.notOk((_c = ctrl) === null || _c === void 0 ? void 0 : _c.operation.includes("42"), "concrete value 42 not in operation");
+        t.ok(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation.includes(":id"), `includes :id pattern — got ${ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation}`);
+        t.notOk(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation.includes("42"), "concrete value 42 not in operation");
     })
         .then(() => nestApp.close())
         .then(() => TestUtil.shutdownScout(t, scout))
         .catch((err) => {
-        var _a;
-        (_a = nestApp) === null || _a === void 0 ? void 0 : _a.close().catch(() => undefined);
+        nestApp === null || nestApp === void 0 ? void 0 : nestApp.close().catch(() => undefined);
         TestUtil.shutdownScout(t, scout, err);
     });
 });

--- a/dist/test/integrations/pg.e2e.js
+++ b/dist/test/integrations/pg.e2e.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const lib_1 = require("../../lib");
 // The hook for PG has to be triggered this way in a typescript context
 // since a partial import like { Client } will not trigger a require
-lib_1.setupRequireIntegrations(["pg"]);
+(0, lib_1.setupRequireIntegrations)(["pg"]);
 const pg_1 = require("pg");
 const sequelize_1 = require("sequelize");
 const test = require("tape");
@@ -17,7 +17,7 @@ let PG_CONTAINER_AND_OPTS = null;
 // NOTE: this test *presumes* that the integration is working, since the integration is require-based
 // it may break if import order is changed (require hook would not have taken place)
 test("the shim works", t => {
-    t.assert(pg_1.Client[integrations_1.getIntegrationSymbol()], "client has the integration symbol");
+    t.assert(pg_1.Client[(0, integrations_1.getIntegrationSymbol)()], "client has the integration symbol");
     t.end();
 });
 // Pseudo test that will start a containerized postgres instance
@@ -25,8 +25,7 @@ TestUtil.startContainerizedPostgresTest(test, cao => {
     PG_CONTAINER_AND_OPTS = cao;
 });
 test("SELECT query during a request is recorded", { timeout: TestUtil.PG_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Setup a PG Client that we'll use later
@@ -79,8 +78,7 @@ test("SELECT query during a request is recorded", { timeout: TestUtil.PG_TEST_TI
     });
 });
 test("CREATE TABLE and INSERT are recorded", { timeout: TestUtil.PG_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Set up a listener for the scout request that will contain the DB record
@@ -152,8 +150,7 @@ test("CREATE TABLE and INSERT are recorded", { timeout: TestUtil.PG_TEST_TIMEOUT
 });
 // https://github.com/scoutapp/scout_apm_node/issues/191
 test("sequelize basic authenticate works", { timeout: TestUtil.PG_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Set up a listener for the scout request that will contain the DB record
@@ -208,8 +205,7 @@ test("sequelize basic authenticate works", { timeout: TestUtil.PG_TEST_TIMEOUT_M
 });
 // https://github.com/scoutapp/scout_apm_node/issues/191
 test("sequelize library works", { timeout: TestUtil.PG_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Set up a listener for the scout request that will contain the DB record

--- a/dist/test/integrations/prisma.e2e.js
+++ b/dist/test/integrations/prisma.e2e.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const lib_1 = require("../../lib");
-lib_1.setupRequireIntegrations(["@prisma/client"]);
+(0, lib_1.setupRequireIntegrations)(["@prisma/client"]);
 const client_1 = require("@prisma/client");
 const test = require("tape");
 const TestUtil = require("../util");
@@ -38,8 +38,7 @@ test("the shim replaces PrismaClient", (t) => {
     t.end();
 });
 test("SQL/Query span is created for a Prisma createMany operation", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -74,8 +73,7 @@ test("SQL/Query span is created for a Prisma createMany operation", { timeout: T
     });
 });
 test("SQL/Query span is created for a Prisma findMany operation", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -107,8 +105,7 @@ test("SQL/Query span is created for a Prisma findMany operation", { timeout: TIM
     });
 });
 test("SQL/Query span has error context when operation fails", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/dist/test/integrations/pug.e2e.js
+++ b/dist/test/integrations/pug.e2e.js
@@ -10,16 +10,15 @@ const types_2 = require("../../lib/types");
 const fixtures_1 = require("../fixtures");
 // The hook for pug has to be triggered this way in a typescript context
 // since a partial import from scout itself (lib/index) will not run the setupRequireIntegrations() code
-lib_1.setupRequireIntegrations(["pug"]);
+(0, lib_1.setupRequireIntegrations)(["pug"]);
 // pug needs to be imported this way to trigger the require integration
 const pug = require("pug");
 test("the shim works", t => {
-    t.assert(integrations_1.getIntegrationSymbol() in pug, "pug export has the integration symbol");
+    t.assert((0, integrations_1.getIntegrationSymbol)() in pug, "pug export has the integration symbol");
     t.end();
 });
 test("pug rendering a string is captured", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Set up a listener for the scout request that will contain the DB record
@@ -53,8 +52,7 @@ test("pug rendering a string is captured", t => {
         .catch(err => TestUtil.shutdownScout(t, scout, err));
 });
 test("pug rendering a file is captured", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Set up a listener for the scout request that will contain the DB record

--- a/dist/test/integrations/redis.e2e.js
+++ b/dist/test/integrations/redis.e2e.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const lib_1 = require("../../lib");
-lib_1.setupRequireIntegrations(["redis"]);
+(0, lib_1.setupRequireIntegrations)(["redis"]);
 const redis_1 = require("redis");
 const test = require("tape");
 const TestUtil = require("../util");
@@ -18,18 +18,17 @@ test("setup: start shared mock agent", (t) => {
 });
 test("redis shim is applied", (t) => {
     const redisModule = require("redis");
-    t.ok(redisModule[integrations_1.getIntegrationSymbol()], "redis module has integration symbol");
+    t.ok(redisModule[(0, integrations_1.getIntegrationSymbol)()], "redis module has integration symbol");
     t.end();
 });
 test("Redis/SET span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
         socketPath: sharedMock.socketPath(),
     }));
-    const client = redis_1.createClient({
+    const client = (0, redis_1.createClient)({
         socket: { host: REDIS_HOST, port: REDIS_PORT },
     });
     const listener = (data) => {
@@ -59,14 +58,13 @@ test("Redis/SET span is created during a request", { timeout: TIMEOUT_MS }, (t) 
     });
 });
 test("Redis/GET span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
         socketPath: sharedMock.socketPath(),
     }));
-    const client = redis_1.createClient({
+    const client = (0, redis_1.createClient)({
         socket: { host: REDIS_HOST, port: REDIS_PORT },
     });
     const listener = (data) => {
@@ -97,15 +95,14 @@ test("Redis/GET span is created during a request", { timeout: TIMEOUT_MS }, (t) 
     });
 });
 test("Redis/DEL span has error context on command failure", { timeout: TIMEOUT_MS }, (t) => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
         socketPath: sharedMock.socketPath(),
     }));
     // Connect to a port that is not listening to force a connection error
-    const client = redis_1.createClient({
+    const client = (0, redis_1.createClient)({
         socket: { host: REDIS_HOST, port: 1 },
     });
     scout.setup()

--- a/dist/test/memory.ext.js
+++ b/dist/test/memory.ext.js
@@ -19,7 +19,7 @@ const TestUtil = require("./util");
 const fixtures_1 = require("./fixtures");
 const loadtest_1 = require("loadtest");
 const util_1 = require("util");
-const loadTest = util_1.promisify(loadtest_1.loadTest);
+const loadTest = (0, util_1.promisify)(loadtest_1.loadTest);
 const LOAD_TEST_CONCURRENCY = parseInt(process.env.LOAD_TEST_CONCURRENCY || "5", 10);
 const LOAD_TEST_RPS = parseInt(process.env.LOAD_TEST_RPS || "20", 10);
 const LOAD_TEST_DURATION_SECONDS = parseInt(process.env.LOAD_TEST_DURATION || "120", 10);
@@ -53,13 +53,13 @@ test("no large memory leaks", { timeout: TestUtil.MEMORY_LEAK_TEST_TIMEOUT_MS },
             memoryUsage: {},
         },
     };
-    const testName = `memory-leak-test-${randomstring_1.generate(5)}`;
+    const testName = `memory-leak-test-${(0, randomstring_1.generate)(5)}`;
     // Launch a small express application as a child process *without* scout
     const expressENV = {
         PORT: yield getPort(),
         SCOUT_NAME: `${testName}-no-scout`,
     };
-    const expressProcess = child_process_1.fork(fixtures_1.FILE_PATHS.EXPRESS_APP_PATH, [], {
+    const expressProcess = (0, child_process_1.fork)(fixtures_1.FILE_PATHS.EXPRESS_APP_PATH, [], {
         env: expressENV,
     });
     t.comment(`app without scout started (PID: [${expressProcess.pid}])`);
@@ -77,7 +77,7 @@ test("no large memory leaks", { timeout: TestUtil.MEMORY_LEAK_TEST_TIMEOUT_MS },
         SCOUT_KEY: process.env.SCOUT_KEY,
         SCOUT_NAME: `${testName}-with-scout`,
     };
-    const expressWithScoutProcess = child_process_1.fork(fixtures_1.FILE_PATHS.EXPRESS_APP_WITH_SCOUT_PATH, [], {
+    const expressWithScoutProcess = (0, child_process_1.fork)(fixtures_1.FILE_PATHS.EXPRESS_APP_WITH_SCOUT_PATH, [], {
         env: expressWithScoutENV,
     });
     t.comment(`app with scout started (PID: [${expressWithScoutProcess.pid}])`);

--- a/dist/test/scout/index.e2e.js
+++ b/dist/test/scout/index.e2e.js
@@ -370,9 +370,8 @@ test("Request auto close works (2 top level)", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/59
 test("Download disabling works via top level config", t => {
-    const config = types_1.buildScoutConfiguration({
+    const config = (0, types_1.buildScoutConfiguration)({
         coreAgentDownload: false,
-        allowShutdown: true,
         monitor: true,
     });
     const scout = new scout_1.Scout(config, { downloadOptions: { disableCache: true } });
@@ -393,11 +392,10 @@ test("Launch disabling works via top level config", t => {
     let scout;
     let socketPath;
     // Ensure a directoy to put the socket in exists
-    fs_extra_1.ensureDir(socketDir)
+    (0, fs_extra_1.ensureDir)(socketDir)
         .then(() => {
-        scout = new scout_1.Scout(types_1.buildScoutConfiguration({
+        scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
             coreAgentLaunch: false,
-            allowShutdown: true,
             monitor: true,
             socketPath: `${socketDir}/core-agent.sock`,
         }));
@@ -408,11 +406,11 @@ test("Launch disabling works via top level config", t => {
         socketPath = filePath;
     })
         // We need to make sure that the socket path doesn't exist
-        .then(() => fs_extra_2.pathExists(socketPath))
+        .then(() => (0, fs_extra_2.pathExists)(socketPath))
         .then(exists => {
         if (exists) {
             t.comment(`removing existing socket path @ [${socketPath}] to prevent use of existing agent`);
-            return fs_extra_2.remove(socketPath);
+            return (0, fs_extra_2.remove)(socketPath);
         }
     })
         // Setup scout
@@ -438,9 +436,8 @@ test("Launch disabling works via top level config", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/59
 test("Custom version specification works via top level config", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         coreAgentVersion: "v1.1.8",
-        allowShutdown: true,
         monitor: true,
     })));
     scout
@@ -457,7 +454,7 @@ test("Application metadata is built and sent", t => {
     const appMeta = new types_1.ApplicationMetadata({
         frameworkVersion: "framework-version-from-app-meta",
     });
-    const config = types_1.buildScoutConfiguration(withMock({ allowShutdown: true, monitor: true }), {
+    const config = (0, types_1.buildScoutConfiguration)(withMock({ monitor: true }), {
         env: {
             SCOUT_FRAMEWORK: "framework-from-env",
             SCOUT_FRAMEWORK_VERSION: "framework-version-from-env",
@@ -558,8 +555,7 @@ test("Multiple ongoing requests are possible at the same time", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/72
 test("Ensure that no requests are received by the agent if monitoring is off", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: false,
     })));
     // Fail the test if a request is sent from the agent
@@ -581,12 +577,11 @@ test("Ensure that no requests are received by the agent if monitoring is off", t
 test("socketPath setting is honored by scout instance", t => {
     let scout;
     // Create a temp directory with a socket for scout to use
-    fs_extra_1.mkdtemp("/tmp/socketpath-config-test-")
+    (0, fs_extra_1.mkdtemp)("/tmp/socketpath-config-test-")
         .then(dir => path.join(dir, "core-agent.sock"))
         .then(socketPath => {
         // Create the scout instance with the custom socketPath
-        scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-            allowShutdown: true,
+        scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
             monitor: false,
             coreAgentLaunch: false,
             coreAgentDownload: false,
@@ -598,8 +593,7 @@ test("socketPath setting is honored by scout instance", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/142
 test("Ignored requests are not sent", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: false,
     })));
     // Fail the test if a request is sent from the agent
@@ -631,8 +625,7 @@ test("Ignored requests are not sent", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export WebTransaction is working", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     const expectedSpanName = "Controller/test-web-transaction-export";
@@ -666,8 +659,7 @@ test("export WebTransaction is working", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export BackgroundTransaction is working", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     const expectedSpanName = "Job/test-background-transaction-export";
@@ -702,8 +694,7 @@ test("export BackgroundTransaction is working", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export Context.add add context (provided scout instance)", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     const listener = (data) => {
@@ -735,8 +726,7 @@ test("export Context.add add context (provided scout instance)", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export Context.addSync to add context (provided scout instance)", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     // TS cannot know that runSync will modify this synchronously
@@ -756,8 +746,7 @@ test("export Context.addSync to add context (provided scout instance)", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/152
 test("export ignoreTransaction successfully ignores transaction (provided scout instance)", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     const listener = (data) => {
@@ -782,8 +771,7 @@ test("export ignoreTransaction successfully ignores transaction (provided scout 
 });
 // https://github.com/scoutapp/scout_apm_node/issues/152
 test("export ignoreTransactionSync successfully ignores transaction (provided scout instance)", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     })));
     // TS cannot know that runSync will modify this synchronously
@@ -806,8 +794,7 @@ test("export ignoreTransactionSync successfully ignores transaction (provided sc
 // https://github.com/scoutapp/scout_apm_node/issues/171
 test("Adding context does not cause socket close", t => {
     // We'll need to create a config to use with the global scout instance
-    const config = types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     }));
     const scout = new scout_1.Scout(config);
@@ -845,8 +832,7 @@ test("Adding context does not cause socket close", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/186
 test("instrumentSync should automatically create a transaction", t => {
     // We'll need to create a config to use with the global scout instance
-    const config = types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     }));
     const scout = new scout_1.Scout(config);
@@ -886,8 +872,7 @@ test("CPU and memory stats should be sent periodically", t => {
     const appMeta = new types_1.ApplicationMetadata({
         frameworkVersion: "framework-version-from-app-meta",
     });
-    const config = types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     }));
     const scout = new scout_1.Scout(config, {
@@ -941,13 +926,12 @@ test("CPU and memory stats should be sent periodically", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/152
 test("export ignoreTransactionSync successfully ignores transaction (global scout instance)", t => {
     // We'll need to create a config to use with the global scout instance
-    const config = types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     }));
     let req;
     let scout;
-    global_1.getOrCreateActiveGlobalScoutInstance(config)
+    (0, global_1.getOrCreateActiveGlobalScoutInstance)(config)
         .then(s => {
         // Save the global scout instance
         scout = s;
@@ -967,15 +951,14 @@ test("export ignoreTransactionSync successfully ignores transaction (global scou
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export Context.addSync to add context (global scout instance)", t => {
     // We'll need to create a config to use with the global scout instance
-    const config = types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     }));
     // TS cannot know that runSync will modify this synchronously
     // so we use any to force the runtime check
     let req;
     let scout;
-    global_1.getOrCreateActiveGlobalScoutInstance(config)
+    (0, global_1.getOrCreateActiveGlobalScoutInstance)(config)
         .then(s => {
         // Save the global scout instance
         scout = s;
@@ -997,11 +980,10 @@ test("export Context.addSync to add context (global scout instance)", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/152
 test("export ignoreTransaction successfully ignores transaction (global scout instance)", t => {
     // We'll need to create a config to use with the global scout instance
-    const config = types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     }));
-    global_1.getOrCreateActiveGlobalScoutInstance(config)
+    (0, global_1.getOrCreateActiveGlobalScoutInstance)(config)
         .then(scout => {
         const listener = () => {
             scout.removeListener(types_1.ScoutEvent.IgnoredRequestProcessingSkipped, listener);
@@ -1023,11 +1005,10 @@ test("export ignoreTransaction successfully ignores transaction (global scout in
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export Context.add add context (global scout instance)", t => {
     // We'll need to create a config to use with the global scout instance
-    const config = types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     }));
-    global_1.getOrCreateActiveGlobalScoutInstance(config)
+    (0, global_1.getOrCreateActiveGlobalScoutInstance)(config)
         .then(scout => {
         const listener = (data) => {
             scout.removeListener(types_1.ScoutEvent.RequestSent, listener);
@@ -1052,12 +1033,11 @@ test("export Context.add add context (global scout instance)", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export Config returns a populated special object", t => {
     // We'll need to create a config to use with the global scout instance
-    const config = types_1.buildScoutConfiguration(withMock({
-        allowShutdown: true,
+    const config = (0, types_1.buildScoutConfiguration)(withMock({
         monitor: true,
     }));
     let scout;
-    global_1.getOrCreateActiveGlobalScoutInstance(config)
+    (0, global_1.getOrCreateActiveGlobalScoutInstance)(config)
         .then(s => {
         scout = s;
         const config = scoutExport.api.Config;
@@ -1073,7 +1053,7 @@ test("export Config returns a populated special object", t => {
 });
 // Cleanup the global isntance(s) that get created
 test("Shutdown the global instance", t => {
-    const inst = global_1.getActiveGlobalScoutInstance();
+    const inst = (0, global_1.getActiveGlobalScoutInstance)();
     if (inst) {
         return TestUtil.shutdownScout(t, inst);
     }

--- a/dist/test/scout/span.e2e.js
+++ b/dist/test/scout/span.e2e.js
@@ -7,8 +7,7 @@ const TestUtil = require("../util");
 const Constants = require("../../lib/constants");
 // https://github.com/scoutapp/scout_apm_node/issues/76
 test("spans should have traces attached", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
         logFilePath: "/tmp/scout.log",
     }), { slowRequestThresholdMs: 50 });
@@ -45,8 +44,7 @@ test("spans should have traces attached", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/107
 test("spans within the threshold should not have traces attached", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Set up a listener for the scout request that gets sent
@@ -79,8 +77,7 @@ test("spans within the threshold should not have traces attached", t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/186
 test("transactions created automatically if not present", t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration({
-        allowShutdown: true,
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)({
         monitor: true,
     }));
     // Set up a listener for the scout request that gets sent

--- a/dist/test/util.d.ts
+++ b/dist/test/util.d.ts
@@ -1,4 +1,7 @@
 /// <reference types="node" />
+/// <reference types="node" />
+/// <reference types="node" />
+/// <reference types="node" />
 import * as net from "net";
 import { Application } from "express";
 import { ChildProcess } from "child_process";
@@ -98,7 +101,7 @@ export declare function stopContainerizedInstanceTest(test: any, provider: () =>
 export declare function stopContainerizedPostgresTest(test: any, provider: () => ContainerAndOpts | null): void;
 export declare function makeConnectedPGClient(provider: () => ContainerAndOpts | null): Promise<Client>;
 export declare function makePGConnectionString(provider: () => ContainerAndOpts | null): Promise<string>;
-declare type ServerShutdownFn = () => void;
+type ServerShutdownFn = () => void;
 export declare function createClientCollectingServer(): [net.Server, ServerShutdownFn];
 export declare function startContainerizedMySQLTest(test: any, cb: (cao: ContainerAndOpts) => void, opts?: {
     containerEnv?: object;

--- a/dist/test/util.js
+++ b/dist/test/util.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.minimal = exports.makeConnectedMySQL2Connection = exports.makeConnectedMySQLConnection = exports.stopContainerizedMySQLTest = exports.startContainerizedMySQLTest = exports.createClientCollectingServer = exports.makePGConnectionString = exports.makeConnectedPGClient = exports.stopContainerizedPostgresTest = exports.stopContainerizedInstanceTest = exports.startContainerizedPostgresTest = exports.killContainer = exports.startContainer = exports.TestContainerStartOpts = exports.buildTestScoutInstanceWithMock = exports.getOrStartSharedMock = exports.buildTestScoutInstance = exports.buildCoreAgentSocketResponse = exports.testConfigurationOverlay = exports.appWithRouterGET = exports.queryAndRenderRandomNumbers = exports.appWithHTTPProxyMiddleware = exports.appWithGETSynchronousError = exports.simpleInstrumentApp = exports.simpleHTML5BoilerplateApp = exports.simpleErrorApp = exports.simpleDynamicSegmentExpressApp = exports.simpleExpressApp = exports.shutdownScoutAndMock = exports.shutdownScout = exports.waitForAgentBufferFlush = exports.cleanup = exports.waitMinutes = exports.waitMs = exports.initializeAgent = exports.bootstrapExternalProcessAgent = exports.MEMORY_LEAK_TEST_TIMEOUT_MS = exports.DASHBOARD_SEND_TIMEOUT_MS = exports.MYSQL_TEST_TIMEOUT_MS = exports.PG_TEST_TIMEOUT_MS = exports.EXPRESS_TEST_TIMEOUT_MS = void 0;
 const tslib_1 = require("tslib");
 const path = require("path");
 const tmp = require("tmp-promise");
@@ -87,15 +88,15 @@ function waitMinutes(mins, t) {
     return waitMs(mins * 60 * 1000, t);
 }
 exports.waitMinutes = waitMinutes;
-// Helper function for cleaning up an agent processe and passing/failing a test
+// Helper function for cleaning up an agent and passing/failing a test
 function cleanup(t, agent, err) {
     if (!agent) {
         t.end(err);
         return Promise.resolve();
     }
-    return agent.getProcess()
-        .then(process => process.kill())
-        .then(() => t.end(err));
+    return agent.disconnect()
+        .then(() => t.end(err))
+        .catch(() => t.end(err));
 }
 exports.cleanup = cleanup;
 // Helper that waits for agent buffer to flush
@@ -190,7 +191,7 @@ function simpleHTML5BoilerplateApp(middleware, templateEngine) {
         app.engine("mustache", require("mustache-express")());
     }
     // Expect all the views to be in the same fixtures/files path
-    const VIEWS_DIR = path.join(app_root_dir_1.get(), "test/fixtures/files");
+    const VIEWS_DIR = path.join((0, app_root_dir_1.get)(), "test/fixtures/files");
     app.set("views", VIEWS_DIR);
     app.set("view engine", templateEngine);
     app.get("/", (req, res) => {
@@ -251,7 +252,7 @@ function queryAndRenderRandomNumbers(middleware, templateEngine, dbClient) {
         app.engine("mustache", require("mustache-express")());
     }
     // Expect all the views to be in the same fixtures/files path
-    const VIEWS_DIR = path.join(app_root_dir_1.get(), "test/fixtures/files");
+    const VIEWS_DIR = path.join((0, app_root_dir_1.get)(), "test/fixtures/files");
     app.set("views", VIEWS_DIR);
     app.set("view engine", templateEngine);
     app.get("/", (req, res) => {
@@ -298,9 +299,9 @@ exports.appWithRouterGET = appWithRouterGET;
 // Test that a given variable is effectively overlaid in the configuration
 function testConfigurationOverlay(t, opts) {
     const { appKey, envValue, expectedValue } = opts;
-    const envKey = types_1.convertCamelCaseToEnvVar(appKey);
+    const envKey = (0, types_1.convertCamelCaseToEnvVar)(appKey);
     const envValueIsSet = envKey in process.env;
-    const defaultConfig = types_1.buildScoutConfiguration();
+    const defaultConfig = (0, types_1.buildScoutConfiguration)();
     t.assert(defaultConfig, "defaultConfig was generated");
     // Only perform this check if we're not currently overriding the value in ENV *during* this test
     // it won't be the default, because we've set it to be so
@@ -310,7 +311,7 @@ function testConfigurationOverlay(t, opts) {
     // Set key at the application level
     const appConfig = {};
     appConfig[appKey] = expectedValue;
-    const appOnlyConfig = types_1.buildScoutConfiguration(appConfig);
+    const appOnlyConfig = (0, types_1.buildScoutConfiguration)(appConfig);
     t.assert(appOnlyConfig, "appOnlyConfig was generated");
     // Only perform this check if we're not currently overriding the value in ENV *during* this test
     // ENV overrides the app so it won't be the app value
@@ -323,7 +324,7 @@ function testConfigurationOverlay(t, opts) {
     process.env[envKey] = envValue;
     // FUTURE: we could also *simulate* process.env here by passing in {env: {...}} to buildScoutConfiguration
     // since we're not trying to do parallel tests yet (env will be changed and reset serially), it's fine
-    const envOverrideConfig = types_1.buildScoutConfiguration(appConfig);
+    const envOverrideConfig = (0, types_1.buildScoutConfiguration)(appConfig);
     t.assert(envOverrideConfig, "envOverrideConfig was generated");
     t.deepEquals(envOverrideConfig[appKey], expectedValue, `config [${appKey}] matches app value when set by app`);
     // Reset the env value
@@ -346,7 +347,7 @@ function buildCoreAgentSocketResponse(json) {
 }
 exports.buildCoreAgentSocketResponse = buildCoreAgentSocketResponse;
 function buildTestScoutInstance(configOverride, options) {
-    const cfg = types_1.buildScoutConfiguration(Object.assign({ allowShutdown: true, monitor: true }, configOverride));
+    const cfg = (0, types_1.buildScoutConfiguration)(Object.assign({ allowShutdown: true, monitor: true }, configOverride));
     return new scout_1.Scout(cfg, options);
 }
 exports.buildTestScoutInstance = buildTestScoutInstance;
@@ -366,7 +367,7 @@ function buildTestScoutInstanceWithMock(configOverride, options) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
         const mockAgent = new mock_agent_1.MockAgent();
         yield mockAgent.start();
-        const cfg = types_1.buildScoutConfiguration(Object.assign({
+        const cfg = (0, types_1.buildScoutConfiguration)(Object.assign({
             allowShutdown: true,
             monitor: true,
             coreAgentLaunch: false,
@@ -418,7 +419,7 @@ class TestContainerStartOpts {
         }
         // Generate a random container name if one wasn't provided
         if (!this.containerName) {
-            this.containerName = `test-${this.imageName}-${randomstring_1.generate(5)}`;
+            this.containerName = `test-${this.imageName}-${(0, randomstring_1.generate)(5)}`;
         }
     }
     imageWithTag() {
@@ -460,7 +461,7 @@ function startContainer(t, optOverrides) {
     ];
     // Spawn the docker container
     t.comment(`spawning container [${opts.imageName}:${opts.tagName}] with name [${opts.containerName}]...`);
-    const containerProcess = child_process_1.spawn(opts.dockerBinPath, args, { detached: true, stdio: "pipe" });
+    const containerProcess = (0, child_process_1.spawn)(opts.dockerBinPath, args, { detached: true, stdio: "pipe" });
     opts.setExecutedStartCommand(`${opts.dockerBinPath} ${args.join(" ")}`);
     let resolved = false;
     let stdoutListener;
@@ -473,7 +474,7 @@ function startContainer(t, optOverrides) {
         if (expected.times && expected.times <= 0) {
             return () => reject(new Error(`[${type}] invalid waitFor: expected.times <= 0`));
         }
-        let times = (_a = expected.times, (_a !== null && _a !== void 0 ? _a : 1));
+        let times = (_a = expected.times) !== null && _a !== void 0 ? _a : 1;
         return (line) => {
             line = line.toString();
             if (!line.includes(expected.phrase)) {
@@ -568,7 +569,7 @@ function startContainer(t, optOverrides) {
             resolve({ containerProcess, opts });
         });
     });
-    return promise_timeout_1.timeout(promise, opts.startTimeoutMs)
+    return (0, promise_timeout_1.timeout)(promise, opts.startTimeoutMs)
         .catch(err => {
         // If we timed out clean up some waiting stuff, shutdown the process
         // since none of the listeners may have triggered, clean them up
@@ -591,13 +592,13 @@ function killContainer(t, opts) {
     const args = ["kill", opts.containerName];
     // Spawn the docker container
     t.comment(`attempting to kill [${opts.containerName}]...`);
-    const dockerKillProcess = child_process_1.spawn(opts.dockerBinPath, args, { detached: true, stdio: "ignore" });
+    const dockerKillProcess = (0, child_process_1.spawn)(opts.dockerBinPath, args, { detached: true, stdio: "ignore" });
     const promise = new Promise((resolve, reject) => {
         dockerKillProcess.on("close", code => {
             resolve(code);
         });
     });
-    return promise_timeout_1.timeout(promise, opts.killTimeoutMs);
+    return (0, promise_timeout_1.timeout)(promise, opts.killTimeoutMs);
 }
 exports.killContainer = killContainer;
 const POSTGRES_IMAGE_NAME = "postgres";
@@ -796,7 +797,7 @@ function makeConnectedMySQLConnection(provider) {
         return Promise.reject(new Error("no CAO in provider"));
     }
     const port = cao.opts.portBinding[3306];
-    const conn = mysql_1.createConnection({
+    const conn = (0, mysql_1.createConnection)({
         user: "root",
         password: "mysql",
         host: "localhost",
@@ -819,7 +820,7 @@ function makeConnectedMySQL2Connection(provider) {
     if (!cao) {
         return Promise.reject(new Error("no CAO in provider"));
     }
-    const conn = mysql2_1.createConnection({
+    const conn = (0, mysql2_1.createConnection)({
         user: "root",
         password: "mysql",
         host: "localhost",

--- a/dist/test/util.js
+++ b/dist/test/util.js
@@ -347,7 +347,7 @@ function buildCoreAgentSocketResponse(json) {
 }
 exports.buildCoreAgentSocketResponse = buildCoreAgentSocketResponse;
 function buildTestScoutInstance(configOverride, options) {
-    const cfg = (0, types_1.buildScoutConfiguration)(Object.assign({ allowShutdown: true, monitor: true }, configOverride));
+    const cfg = (0, types_1.buildScoutConfiguration)(Object.assign({ monitor: true }, configOverride));
     return new scout_1.Scout(cfg, options);
 }
 exports.buildTestScoutInstance = buildTestScoutInstance;
@@ -368,7 +368,6 @@ function buildTestScoutInstanceWithMock(configOverride, options) {
         const mockAgent = new mock_agent_1.MockAgent();
         yield mockAgent.start();
         const cfg = (0, types_1.buildScoutConfiguration)(Object.assign({
-            allowShutdown: true,
             monitor: true,
             coreAgentLaunch: false,
             coreAgentDownload: false,

--- a/dist/test/util.unit.js
+++ b/dist/test/util.unit.js
@@ -7,8 +7,8 @@ const Constants = require("../lib/constants");
 const TestFixtures = require("./fixtures");
 test("splitAgentResponse parses well formed headers", t => {
     // Build a buffer with a message
-    const buf = util_1.buildCoreAgentSocketResponse(TestFixtures.RESPONSES.V1.REGISTER.COMPLETE);
-    const result = types_1.splitAgentResponses(buf);
+    const buf = (0, util_1.buildCoreAgentSocketResponse)(TestFixtures.RESPONSES.V1.REGISTER.COMPLETE);
+    const result = (0, types_1.splitAgentResponses)(buf);
     t.assert(result, "result was returned");
     t.equals(result.framed.length, 1, "exactly one framed message was returned");
     t.equals(result.remaining.length, 0, "no leftover bytes");
@@ -16,9 +16,9 @@ test("splitAgentResponse parses well formed headers", t => {
 });
 test("splitAgentResponse parses partial response", t => {
     // Build a buffer with a partial message, but write the length to be the complete message
-    const buf = util_1.buildCoreAgentSocketResponse(TestFixtures.RESPONSES.V1.REGISTER.PARTIAL);
+    const buf = (0, util_1.buildCoreAgentSocketResponse)(TestFixtures.RESPONSES.V1.REGISTER.PARTIAL);
     buf.writeUInt32BE(TestFixtures.RESPONSES.V1.REGISTER.COMPLETE.length, 0);
-    const result = types_1.splitAgentResponses(buf);
+    const result = (0, types_1.splitAgentResponses)(buf);
     t.assert(result, "result was returned");
     t.equals(result.framed.length, 0, "no framed full message was returned");
     t.equals(result.remaining.length, TestFixtures.RESPONSES.V1.REGISTER.PARTIAL.length + 4, "remaining (badly-framed) bytes are partial length + 4 byte amount");
@@ -27,10 +27,10 @@ test("splitAgentResponse parses partial response", t => {
 test("splitAgentResponse parses multiple responses", t => {
     // Build a buffer with a message
     const buf = Buffer.concat([
-        util_1.buildCoreAgentSocketResponse(TestFixtures.RESPONSES.V1.REGISTER.COMPLETE),
-        util_1.buildCoreAgentSocketResponse(TestFixtures.RESPONSES.V1.REGISTER.COMPLETE),
+        (0, util_1.buildCoreAgentSocketResponse)(TestFixtures.RESPONSES.V1.REGISTER.COMPLETE),
+        (0, util_1.buildCoreAgentSocketResponse)(TestFixtures.RESPONSES.V1.REGISTER.COMPLETE),
     ]);
-    const result = types_1.splitAgentResponses(buf);
+    const result = (0, types_1.splitAgentResponses)(buf);
     t.assert(result, "result was returned");
     t.equals(result.framed.length, 2, "exactly two framed message was returned");
     t.equals(result.remaining.length, 0, "no leftover bytes");
@@ -38,13 +38,13 @@ test("splitAgentResponse parses multiple responses", t => {
 });
 test("scrubURLParams scrubs params properly", t => {
     // Build a buffer with a message
-    const scrubbed = types_1.scrubRequestPathParams("https://localhost/some/path?password=test");
+    const scrubbed = (0, types_1.scrubRequestPathParams)("https://localhost/some/path?password=test");
     t.assert(scrubbed.includes(`password=${Constants.DEFAULT_PARAM_SCRUB_REPLACEMENT}`), "scrubbed string has password replaced");
     t.end();
 });
 test("scrubURLToPath scrubs URL down to path", t => {
     // Build a buffer with a message
-    const scrubbed = types_1.scrubRequestPath("https://localhost/some/path?password=test");
+    const scrubbed = (0, types_1.scrubRequestPath)("https://localhost/some/path?password=test");
     t.equals(scrubbed, "https://localhost/some/path");
     t.end();
 });

--- a/dist/test/winston.e2e.js
+++ b/dist/test/winston.e2e.js
@@ -14,7 +14,7 @@ test("Winston logger is successfully logged to", t => {
         logger = winston.createLogger({ transports: [
                 new winston.transports.File({ filename }),
             ] });
-        const logFn = types_1.buildWinstonLogFn(logger);
+        const logFn = (0, types_1.buildWinstonLogFn)(logger);
         return TestUtil.buildTestScoutInstanceWithMock({}, { logFn });
     })
         .then(({ scout: s, mockAgent: ma }) => {
@@ -51,8 +51,8 @@ test("Scout inherits winston logger level", t => {
                 new winston.transports.File({ filename }),
             ],
         });
-        const logFn = types_1.buildWinstonLogFn(logger);
-        scoutConfig = { allowShutdown: true, monitor: true };
+        const logFn = (0, types_1.buildWinstonLogFn)(logger);
+        scoutConfig = { monitor: true };
         t.equals(scoutConfig.logLevel, undefined, "scout log level is initially undefined");
         return TestUtil.buildTestScoutInstanceWithMock(scoutConfig, { logFn });
     })

--- a/lib/agents/external-process.ts
+++ b/lib/agents/external-process.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from "events";
 import * as Errors from "../errors";
 import * as Constants from "../constants";
-import { pathExists, remove } from "fs-extra";
+import { pathExists } from "fs-extra";
 import { Socket, createConnection } from "net";
-import { spawn, ChildProcess } from "child_process";
+import { spawn } from "child_process";
 import { createPool, Pool } from "generic-pool";
 import { timeout, TimeoutError } from "promise-timeout";
 
@@ -59,7 +59,6 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
     private socketConnected: boolean = false;
     private socketConnectionAttempts: number = 0;
 
-    private detachedProcess: ChildProcess;
     private stopped: boolean = true;
     private logFn: LogFn;
 
@@ -95,12 +94,11 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
 
     /** @see Agent */
     public start(): Promise<this> {
-
         return this.peerRunning()
             .then(exists => {
-                // If the socket doesn't already exist, start the process as configured
                 if (exists) {
-                    this.logFn("[scout/external-process] Socket already present", LogLevel.Warn);
+                    this.logFn("[scout/external-process] Core agent already running, skipping launch", LogLevel.Debug);
+                    return this;
                 }
 
                 return this.startProcess();
@@ -292,36 +290,13 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
     /**
      * Check if the process is present
      */
-    public getProcess(): Promise<ChildProcess> {
-        if (this.opts.disallowLaunch) {
-            return Promise.reject(new Errors.NoProcessReference("launch disabled"));
-        }
-
-        if (this.detachedProcess === undefined || this.detachedProcess === null) {
-            return Promise.reject(new Errors.NoProcessReference());
-        }
-
-        return Promise.resolve(this.detachedProcess);
-    }
-
     /**
-     * Stop the process (if one is running)
+     * No-op: the core agent is a daemon and manages its own lifecycle.
+     * Workers must not kill it — doing so would take down all other workers
+     * sharing the same socket.
      */
     public stopProcess(): Promise<void> {
-        return this.getProcess()
-            .then(p => {
-                this.stopped = true;
-                // The process tree itself must be killed
-                // otherwise instances of core-agent may be leaked.
-                if (process.platform === "linux" && p.pid !== undefined) { process.kill(-1 * p.pid); }
-
-                p.kill();
-            })
-        // Remove the socket path
-            .then(() => remove(this.getSocketPath()))
-            .catch(err => {
-                this.logFn(`[scout/external-process] Process stop failed:\n${err}`, LogLevel.Error);
-            });
+        return Promise.resolve();
     }
 
     /**
@@ -618,6 +593,7 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
         const socketPath = this.getSocketPath();
         const args = [
             "start",
+            "--daemonize", "true",
             this.opts.isTCPSocket() ? "--tcp" : "--socket",
             socketPath,
         ];
@@ -630,11 +606,11 @@ export default class ExternalProcessAgent extends EventEmitter implements Agent 
 
         this.logFn(`[scout/external-process] binary path: [${this.opts.binPath}]`, LogLevel.Debug);
         this.logFn(`[scout/external-process] args: [${args}]`, LogLevel.Debug);
-        this.detachedProcess = spawn(this.opts.binPath, args, {
+        const proc = spawn(this.opts.binPath, args, {
             detached: true,
             stdio: "ignore",
         });
-        this.detachedProcess.unref();
+        proc.unref();
 
         // Wait until process is listening on the given socket port
         return new Promise((resolve, reject) => {

--- a/lib/scout/index.ts
+++ b/lib/scout/index.ts
@@ -374,11 +374,7 @@ export class Scout extends EventEmitter {
 
         return this.agent
             .disconnect()
-            .then(() => {
-                if (this.config.allowShutdown && this.agent) {
-                    return this.agent.stopProcess();
-                }
-            })
+            .then(() => undefined)
         // Remove the agent, emit the shutdown event
             .then(() => {
                 this.agent = null;

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -199,7 +199,6 @@ export interface ScoutConfiguration {
     socketPath: string;
     logFilePath: "stdout" | string;
     httpProxy: string;
-    allowShutdown: boolean;
     monitor: boolean;
 
     // Scout ingest host — passed to core-agent as --ingest-url (reads SCOUT_HOST env var)

--- a/test/agents/external-process.e2e.ts
+++ b/test/agents/external-process.e2e.ts
@@ -1,5 +1,4 @@
 import * as test from "tape";
-import { ChildProcess } from "child_process";
 import { mkdtemp } from "fs-extra";
 import * as path from "path";
 
@@ -29,17 +28,14 @@ const SKIP_BINARY_TESTS = process.env.ENABLE_BINARY_TESTS !== "true";
 
 test(`external process can be launched locally (v${TestConstants.TEST_APP_VERSION})`, {skip: SKIP_BINARY_TESTS}, t => {
     let agent: ExternalProcessAgent;
-    let process: ChildProcess;
 
     // Create the external process agent
     TestUtil.bootstrapExternalProcessAgent(t, TestConstants.TEST_APP_VERSION)
         .then(a => agent = a)
-    // Start the agent & check it was started by viewing the process
         .then(() => agent.start())
-        .then(() => agent.getProcess())
-        .then(p => process = p)
-        .then(() => t.assert(process, "process was started by this agent"))
-    // Cleanup the process & end test
+        .then(() => agent.connect())
+        .then(status => t.assert(status.connected, "agent is connected after start"))
+    // Cleanup & end test
         .then(() => TestUtil.cleanup(t, agent))
         .catch(err => TestUtil.cleanup(t, agent, err));
 });
@@ -540,26 +536,22 @@ test(`Request with 'Controller' span works, after waiting for flush (v${TestCons
 });
 
 test("Support starting scout with a completely external core-agent", {skip: SKIP_BINARY_TESTS}, t => {
-    // Create the external process agent, with special function for building the proc opts with
+    let agent: ExternalProcessAgent;
+    // Create the external process agent with launch disabled — simulates connecting to an
+    // externally-managed daemon.
     TestUtil.bootstrapExternalProcessAgent(
         t,
         TestConstants.TEST_APP_VERSION,
         {buildProcOpts: (binPath, uri) => new ProcessOptions(binPath, uri, {disallowLaunch: true})},
     )
-    // Attempt to shut down the agent immediately which shouldn't work because there is no process
-        .then(agent => agent.getProcess())
-    // Cleanup the process & end test
-        .then(() => {
-            t.fail("shutdown succeeded on an agent with no process");
-            t.end();
-        })
+        .then(a => agent = a)
+        .then(() => agent.start())
         .catch(err => {
-            if (err instanceof Errors.NoProcessReference) {
-                t.pass("NoProcessReference error was returned");
+            if (err instanceof Errors.AgentLaunchDisabled) {
+                t.pass("AgentLaunchDisabled error returned when launch is disabled");
                 t.end();
                 return;
             }
-
             t.end(err);
         });
 });

--- a/test/agents/external-process.e2e.ts
+++ b/test/agents/external-process.e2e.ts
@@ -556,6 +556,37 @@ test("Support starting scout with a completely external core-agent", {skip: SKIP
         });
 });
 
+test("first start() waits for daemon startup, subsequent start() calls resolve instantly", {skip: SKIP_BINARY_TESTS}, t => {
+    let agent: ExternalProcessAgent;
+
+    TestUtil.bootstrapExternalProcessAgent(t, TestConstants.TEST_APP_VERSION)
+        .then(a => agent = a)
+    // First start() — daemon not yet running, must wait DEFAULT_BIN_STARTUP_WAIT_MS
+        .then(() => {
+            const t0 = Date.now();
+            return agent.start().then(() => Date.now() - t0);
+        })
+        .then(elapsed => {
+            t.assert(
+                elapsed >= Constants.DEFAULT_BIN_STARTUP_WAIT_MS,
+                `first start() took ${elapsed}ms (expected >= ${Constants.DEFAULT_BIN_STARTUP_WAIT_MS}ms)`,
+            );
+        })
+    // Second start() — peerRunning() returns true, returns this immediately
+        .then(() => {
+            const t0 = Date.now();
+            return agent.start().then(() => Date.now() - t0);
+        })
+        .then(elapsed => {
+            t.assert(
+                elapsed < Constants.DEFAULT_BIN_STARTUP_WAIT_MS,
+                `second start() took ${elapsed}ms (expected < ${Constants.DEFAULT_BIN_STARTUP_WAIT_MS}ms)`,
+            );
+        })
+        .then(() => TestUtil.cleanup(t, agent))
+        .catch(err => TestUtil.cleanup(t, agent, err));
+});
+
 test("Timeout agent messages", {skip: SKIP_BINARY_TESTS}, t => {
     let agent: ExternalProcessAgent;
 

--- a/test/dashboard-send.ext.ts
+++ b/test/dashboard-send.ext.ts
@@ -67,7 +67,6 @@ const pug = require("pug");
 test("Test scout app launch dashboard send", {timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS}, t => {
     // Build scout config & app meta for test
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -113,7 +112,6 @@ test("Test scout app launch dashboard send", {timeout: TestUtil.DASHBOARD_SEND_T
 // https://github.com/scoutapp/scout_apm_node/issues/71
 test("Scout sends basic controller span to dashboard", {timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS}, t => {
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -169,7 +167,6 @@ TestUtil.startContainerizedPostgresTest(test, cao => {
 // https://github.com/scoutapp/scout_apm_node/issues/83
 test("transaction with with postgres DB query to dashboard", {timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS}, t => {
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -237,7 +234,6 @@ test("transaction with with postgres DB query to dashboard", {timeout: TestUtil.
 // https://github.com/scoutapp/scout_apm_node/issues/140
 test("Many select statments and a render are in the right order", {timeout: TestUtil.PG_TEST_TIMEOUT_MS * 1000}, t => {
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     });
     const appMeta = new ApplicationMetadata(config, {frameworkVersion: "test"});
@@ -357,7 +353,6 @@ TestUtil.startContainerizedMySQLTest(test, cao => {
 test("transaction with mysql query to dashboard", {timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS}, t => {
     // Build scout config & app meta for test
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -423,7 +418,6 @@ test("transaction with mysql query to dashboard", {timeout: TestUtil.DASHBOARD_S
 test("transaction with mysql2 query to dashboard", {timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS}, t => {
     // Build scout config & app meta for test
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });
@@ -497,7 +491,6 @@ TestUtil.stopContainerizedMySQLTest(test, () => MYSQL_CONTAINER_AND_OPTS);
 test("Express pug integration dashboard send", {timeout: TestUtil.DASHBOARD_SEND_TIMEOUT_MS}, t => {
     // Build scout config & app meta for test
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         name: TestConstants.TEST_SCOUT_NAME,
     });

--- a/test/express.e2e.ts
+++ b/test/express.e2e.ts
@@ -51,7 +51,6 @@ test("Simple operation", t => {
     // Create an application and setup scout middleware
     const app: Application & ApplicationWithScout = TestUtil.simpleExpressApp(scoutMiddleware({
         config: buildScoutConfiguration(withMock({
-            allowShutdown: true,
             monitor: true,
         })),
         requestTimeoutMs: 0, // disable request timeout to stop test from hanging
@@ -103,7 +102,6 @@ test("Dynamic segment routes (uses global instance)", {timeout: TestUtil.EXPRESS
     const app: Application & ApplicationWithScout = TestUtil.simpleDynamicSegmentExpressApp(
         scoutMiddleware({
             config: buildScoutConfiguration(withMock({
-                allowShutdown: true,
                 monitor: true,
             })),
             requestTimeoutMs: 0, // disable request timeout to stop test from hanging
@@ -170,7 +168,6 @@ test("Application which errors (uses global scout instance)", {timeout: TestUtil
     // Create an application and setup scout middleware
     const app: Application & ApplicationWithScout = TestUtil.simpleErrorApp(scoutMiddleware({
         config: buildScoutConfiguration(withMock({
-            allowShutdown: true,
             monitor: true,
         })),
         requestTimeoutMs: 0, // disable request timeout to stop test from hanging
@@ -197,7 +194,6 @@ test("Application which errors (uses global scout instance)", {timeout: TestUtil
 test("express ignores a path (exact path, with dynamic segments)", TEST_OPTS, t => {
     const path = "/dynamic/:segment";
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
         ignore: [path],
     })));
@@ -231,7 +227,6 @@ test("express ignores a path (exact path, with dynamic segments)", TEST_OPTS, t 
 test("express ignores a path (exact path, static)", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t => {
     const path = "/";
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
         ignore: [path],
     })));
@@ -266,7 +261,6 @@ test("express ignores a path (prefix, with dynamic segments)", {timeout: TestUti
     const path = "/dynamic/:segment";
     const prefix = "/dynamic";
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
         ignore: [prefix],
     })));
@@ -302,7 +296,6 @@ test("express ignores a path (prefix, static)", {timeout: TestUtil.EXPRESS_TEST_
     const path = "/echo-by-post";
     const prefix = "/echo";
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
         ignore: [prefix],
     })));
@@ -337,7 +330,6 @@ test("express ignores a path (prefix, static)", {timeout: TestUtil.EXPRESS_TEST_
 
 test("URI params are filtered", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
     // Create an application and setup scout middleware
@@ -385,7 +377,6 @@ test("URI params are filtered", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t =
 
 test("URI filtered down to path", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
         uriReporting: URIReportingLevel.Path,
     })));
@@ -435,7 +426,6 @@ test("URI filtered down to path", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("Pug integration works", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -492,7 +482,6 @@ test("Pug integration works", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t => 
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("ejs integration works", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -550,7 +539,6 @@ test("ejs integration works", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t => 
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("mustache integration works", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -607,7 +595,6 @@ test("mustache integration works", {timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS}, 
 // https://github.com/scoutapp/scout_apm_node/issues/129
 test("Nested spans on the top level controller have parent ID specified", TEST_OPTS, t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -669,7 +656,6 @@ test("Nested spans on the top level controller have parent ID specified", TEST_O
 // https://github.com/scoutapp/scout_apm_node/issues/150
 test("Unknown routes should not be recorded", TEST_OPTS, t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -708,7 +694,6 @@ test("Unknown routes should not be recorded", TEST_OPTS, t => {
 // https://github.com/scoutapp/scout_apm_node/issues/68
 test("Request queue time should be recorded", TEST_OPTS, t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 

--- a/test/integration/express.int.ts
+++ b/test/integration/express.int.ts
@@ -19,7 +19,6 @@ type AppWithScout = Application & ApplicationWithScout;
 
 function buildScoutWithMock(mock: MockAgent, extra?: object) {
     return buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/test/integration/libraries.int.ts
+++ b/test/integration/libraries.int.ts
@@ -28,7 +28,6 @@ type AppWithScout = Application & ApplicationWithScout;
 
 function buildConfig(mock: MockAgent) {
     return buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/test/integration/nest.int.ts
+++ b/test/integration/nest.int.ts
@@ -36,7 +36,6 @@ class TestModule {}
 
 function buildConfig(mock: MockAgent, extra?: object) {
     return buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/test/integrations/ejs.e2e.ts
+++ b/test/integrations/ejs.e2e.ts
@@ -34,7 +34,6 @@ test("the shim works", t => {
 
 test("ejs rendering a string is captured", t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -83,7 +82,6 @@ test("ejs rendering a string is captured", t => {
 
 test("ejs rendering a file is captured", t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 

--- a/test/integrations/express.e2e.ts
+++ b/test/integrations/express.e2e.ts
@@ -46,7 +46,6 @@ test("express object still has native props", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/127
 test("errors in controller functions trigger context updates", t => {
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     });
     const scout = new Scout(config);
@@ -94,7 +93,6 @@ test("errors in controller functions trigger context updates", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/238
 test("express Routers are recorded (one level)", t => {
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     });
     const scout = new Scout(config);
@@ -166,7 +164,6 @@ test("express Routers are recorded (one level)", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/238
 test("express Routers are recorded (two levels)", t => {
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     });
     const scout = new Scout(config);

--- a/test/integrations/fetch.e2e.ts
+++ b/test/integrations/fetch.e2e.ts
@@ -42,7 +42,6 @@ if (NODE_MAJOR < 18) {
 } else {
     test("HTTP/GET span is created for a fetch request", { timeout: TIMEOUT_MS }, (t) => {
         const scout = new Scout(buildScoutConfiguration({
-            allowShutdown: true,
             monitor: true,
             coreAgentDownload: false,
             coreAgentLaunch: false,
@@ -75,7 +74,6 @@ if (NODE_MAJOR < 18) {
 
     test("HTTP/POST span is created for a fetch POST request", { timeout: TIMEOUT_MS }, (t) => {
         const scout = new Scout(buildScoutConfiguration({
-            allowShutdown: true,
             monitor: true,
             coreAgentDownload: false,
             coreAgentLaunch: false,
@@ -109,7 +107,6 @@ if (NODE_MAJOR < 18) {
 
     test("HTTP/GET span has error context on network failure", { timeout: TIMEOUT_MS }, (t) => {
         const scout = new Scout(buildScoutConfiguration({
-            allowShutdown: true,
             monitor: true,
             coreAgentDownload: false,
             coreAgentLaunch: false,
@@ -147,7 +144,6 @@ if (NODE_MAJOR < 18) {
 
     test("concurrent fetch requests each get their own span", { timeout: TIMEOUT_MS }, (t) => {
         const scout = new Scout(buildScoutConfiguration({
-            allowShutdown: true,
             monitor: true,
             coreAgentDownload: false,
             coreAgentLaunch: false,

--- a/test/integrations/http.e2e.ts
+++ b/test/integrations/http.e2e.ts
@@ -38,7 +38,6 @@ test("the shim works", t => {
 
 test("http connections are captured", t => {
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     });
     const scout = new Scout(config);

--- a/test/integrations/https.e2e.ts
+++ b/test/integrations/https.e2e.ts
@@ -37,7 +37,6 @@ test("the shim works", t => {
 
 test("https.get triggers proper span creation", t => {
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     });
     const scout = new Scout(config);
@@ -96,7 +95,6 @@ test("https.get triggers proper span creation", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/209
 test("An endpoint using http-proxy-middleware should capture proxied requests", t => {
     const config = buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     });
     const scout = new Scout(config);

--- a/test/integrations/ioredis.e2e.ts
+++ b/test/integrations/ioredis.e2e.ts
@@ -26,7 +26,6 @@ test("ioredis shim is applied", (t) => {
 
 test("Redis/SET span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -64,7 +63,6 @@ test("Redis/SET span is created during a request", { timeout: TIMEOUT_MS }, (t) 
 
 test("Redis/GET span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/test/integrations/mongodb.e2e.ts
+++ b/test/integrations/mongodb.e2e.ts
@@ -28,7 +28,6 @@ test("mongodb shim is applied", (t) => {
 
 test("MongoDB/insertOne span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -71,7 +70,6 @@ test("MongoDB/insertOne span is created during a request", { timeout: TIMEOUT_MS
 
 test("MongoDB/find span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -113,7 +111,6 @@ test("MongoDB/find span is created during a request", { timeout: TIMEOUT_MS }, (
 
 test("MongoDB span has error context on command failure", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/test/integrations/mustache.e2e.ts
+++ b/test/integrations/mustache.e2e.ts
@@ -36,7 +36,6 @@ test("the shim works", t => {
 
 test("mustache rendering a string is captured", t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 

--- a/test/integrations/mysql.e2e.ts
+++ b/test/integrations/mysql.e2e.ts
@@ -43,7 +43,6 @@ TestUtil.startContainerizedMySQLTest(test, cao => {
 
 test("SELECT query during a request is recorded", {timeout: TestUtil.MYSQL_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 

--- a/test/integrations/mysql2.e2e.ts
+++ b/test/integrations/mysql2.e2e.ts
@@ -57,7 +57,6 @@ test("the shim works", t => {
 
 test("SELECT query during a request is recorded", t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 

--- a/test/integrations/nest.e2e.ts
+++ b/test/integrations/nest.e2e.ts
@@ -61,7 +61,7 @@ test("nestMiddleware is a function", (t) => {
 });
 
 test("NestJS app instruments root route", { timeout: TIMEOUT }, (t) => {
-    const config = buildScoutConfiguration({ allowShutdown: true, monitor: true });
+    const config = buildScoutConfiguration({ monitor: true });
     const scout = new Scout(config);
     let nestApp: any;
 
@@ -92,7 +92,7 @@ test("NestJS app instruments root route", { timeout: TIMEOUT }, (t) => {
 });
 
 test("NestJS parameterised route captures pattern not value", { timeout: TIMEOUT }, (t) => {
-    const config = buildScoutConfiguration({ allowShutdown: true, monitor: true });
+    const config = buildScoutConfiguration({ monitor: true });
     const scout = new Scout(config);
     let nestApp: any;
 

--- a/test/integrations/pg.e2e.ts
+++ b/test/integrations/pg.e2e.ts
@@ -40,7 +40,6 @@ TestUtil.startContainerizedPostgresTest(test, cao => {
 
 test("SELECT query during a request is recorded", {timeout: TestUtil.PG_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -106,7 +105,6 @@ test("SELECT query during a request is recorded", {timeout: TestUtil.PG_TEST_TIM
 
 test("CREATE TABLE and INSERT are recorded", {timeout: TestUtil.PG_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -188,7 +186,6 @@ test("CREATE TABLE and INSERT are recorded", {timeout: TestUtil.PG_TEST_TIMEOUT_
 // https://github.com/scoutapp/scout_apm_node/issues/191
 test("sequelize basic authenticate works", {timeout: TestUtil.PG_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -251,7 +248,6 @@ test("sequelize basic authenticate works", {timeout: TestUtil.PG_TEST_TIMEOUT_MS
 // https://github.com/scoutapp/scout_apm_node/issues/191
 test("sequelize library works", {timeout: TestUtil.PG_TEST_TIMEOUT_MS}, t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 

--- a/test/integrations/prisma.e2e.ts
+++ b/test/integrations/prisma.e2e.ts
@@ -52,7 +52,6 @@ test("the shim replaces PrismaClient", (t) => {
 
 test("SQL/Query span is created for a Prisma createMany operation", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -94,7 +93,6 @@ test("SQL/Query span is created for a Prisma createMany operation", { timeout: T
 
 test("SQL/Query span is created for a Prisma findMany operation", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -133,7 +131,6 @@ test("SQL/Query span is created for a Prisma findMany operation", { timeout: TIM
 
 test("SQL/Query span has error context when operation fails", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/test/integrations/pug.e2e.ts
+++ b/test/integrations/pug.e2e.ts
@@ -35,7 +35,6 @@ test("the shim works", t => {
 
 test("pug rendering a string is captured", t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -80,7 +79,6 @@ test("pug rendering a string is captured", t => {
 
 test("pug rendering a file is captured", t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 

--- a/test/integrations/redis.e2e.ts
+++ b/test/integrations/redis.e2e.ts
@@ -27,7 +27,6 @@ test("redis shim is applied", (t) => {
 
 test("Redis/SET span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -70,7 +69,6 @@ test("Redis/SET span is created during a request", { timeout: TIMEOUT_MS }, (t) 
 
 test("Redis/GET span is created during a request", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -114,7 +112,6 @@ test("Redis/GET span is created during a request", { timeout: TIMEOUT_MS }, (t) 
 
 test("Redis/DEL span has error context on command failure", { timeout: TIMEOUT_MS }, (t) => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,

--- a/test/scout/index.e2e.ts
+++ b/test/scout/index.e2e.ts
@@ -418,7 +418,6 @@ test("Request auto close works (2 top level)", t => {
 test("Download disabling works via top level config", t => {
     const config = buildScoutConfiguration({
         coreAgentDownload: false,
-        allowShutdown: true,
         monitor: true,
     });
     const scout = new Scout(config, {downloadOptions: {disableCache: true}});
@@ -448,7 +447,6 @@ test("Launch disabling works via top level config", t => {
         .then(() => {
             scout = new Scout(buildScoutConfiguration({
                 coreAgentLaunch: false,
-                allowShutdown: true,
                 monitor: true,
                 socketPath: `${socketDir}/core-agent.sock`,
             }));
@@ -493,7 +491,6 @@ test("Launch disabling works via top level config", t => {
 test("Custom version specification works via top level config", t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
         coreAgentVersion: "v1.1.8", // older version (default is newer)
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -514,7 +511,7 @@ test("Application metadata is built and sent", t => {
     });
 
     const config = buildScoutConfiguration(
-        withMock({allowShutdown: true, monitor: true}),
+        withMock({monitor: true}),
         {
             env: {
                 SCOUT_FRAMEWORK: "framework-from-env",
@@ -631,7 +628,6 @@ test("Multiple ongoing requests are possible at the same time", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/72
 test("Ensure that no requests are received by the agent if monitoring is off", t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: false,
     })));
 
@@ -663,7 +659,6 @@ test("socketPath setting is honored by scout instance", t => {
         .then(socketPath => {
             // Create the scout instance with the custom socketPath
             scout = new Scout(buildScoutConfiguration({
-                allowShutdown: true,
                 monitor: false,
                 coreAgentLaunch: false,
                 coreAgentDownload: false,
@@ -678,7 +673,6 @@ test("socketPath setting is honored by scout instance", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/142
 test("Ignored requests are not sent", t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: false,
     })));
 
@@ -718,7 +712,6 @@ test("Ignored requests are not sent", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export WebTransaction is working", t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -761,7 +754,6 @@ test("export WebTransaction is working", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export BackgroundTransaction is working", t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -804,7 +796,6 @@ test("export BackgroundTransaction is working", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export Context.add add context (provided scout instance)", t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -845,7 +836,6 @@ test("export Context.add add context (provided scout instance)", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/141
 test("export Context.addSync to add context (provided scout instance)", t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -872,7 +862,6 @@ test("export Context.addSync to add context (provided scout instance)", t => {
 test("export ignoreTransaction successfully ignores transaction (provided scout instance)", t => {
 
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -907,7 +896,6 @@ test("export ignoreTransaction successfully ignores transaction (provided scout 
 // https://github.com/scoutapp/scout_apm_node/issues/152
 test("export ignoreTransactionSync successfully ignores transaction (provided scout instance)", t => {
     const scout = new Scout(buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     })));
 
@@ -938,7 +926,6 @@ test("export ignoreTransactionSync successfully ignores transaction (provided sc
 test("Adding context does not cause socket close", t => {
     // We'll need to create a config to use with the global scout instance
     const config = buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -983,7 +970,6 @@ test("Adding context does not cause socket close", t => {
 test("instrumentSync should automatically create a transaction", t => {
     // We'll need to create a config to use with the global scout instance
     const config = buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -1031,7 +1017,6 @@ test("CPU and memory stats should be sent periodically", t => {
     });
 
     const config = buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -1095,7 +1080,6 @@ test("CPU and memory stats should be sent periodically", t => {
 test("export ignoreTransactionSync successfully ignores transaction (global scout instance)", t => {
     // We'll need to create a config to use with the global scout instance
     const config = buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -1128,7 +1112,6 @@ test("export ignoreTransactionSync successfully ignores transaction (global scou
 test("export Context.addSync to add context (global scout instance)", t => {
     // We'll need to create a config to use with the global scout instance
     const config = buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -1165,7 +1148,6 @@ test("export Context.addSync to add context (global scout instance)", t => {
 test("export ignoreTransaction successfully ignores transaction (global scout instance)", t => {
     // We'll need to create a config to use with the global scout instance
     const config = buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -1199,7 +1181,6 @@ test("export ignoreTransaction successfully ignores transaction (global scout in
 test("export Context.add add context (global scout instance)", t => {
     // We'll need to create a config to use with the global scout instance
     const config = buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -1237,7 +1218,6 @@ test("export Context.add add context (global scout instance)", t => {
 test("export Config returns a populated special object", t => {
     // We'll need to create a config to use with the global scout instance
     const config = buildScoutConfiguration(withMock({
-        allowShutdown: true,
         monitor: true,
     }));
 

--- a/test/scout/span.e2e.ts
+++ b/test/scout/span.e2e.ts
@@ -29,7 +29,6 @@ import * as Constants from "../../lib/constants";
 test("spans should have traces attached", t => {
     const scout = new Scout(
         buildScoutConfiguration({
-            allowShutdown: true,
             monitor: true,
             logFilePath: "/tmp/scout.log",
         }),
@@ -75,7 +74,6 @@ test("spans should have traces attached", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/107
 test("spans within the threshold should not have traces attached", t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 
@@ -115,7 +113,6 @@ test("spans within the threshold should not have traces attached", t => {
 // https://github.com/scoutapp/scout_apm_node/issues/186
 test("transactions created automatically if not present", t => {
     const scout = new Scout(buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
     }));
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -448,7 +448,7 @@ export function buildTestScoutInstance(
     options?: Partial<ScoutOptions>,
 ): Scout {
     const cfg = buildScoutConfiguration(
-        Object.assign({allowShutdown: true, monitor: true}, configOverride),
+        Object.assign({monitor: true}, configOverride),
     );
     return new Scout(cfg, options);
 }
@@ -474,7 +474,6 @@ export async function buildTestScoutInstanceWithMock(
     await mockAgent.start();
     const cfg = buildScoutConfiguration(Object.assign(
         {
-            allowShutdown: true,
             monitor: true,
             coreAgentLaunch: false,
             coreAgentDownload: false,

--- a/test/util.ts
+++ b/test/util.ts
@@ -126,12 +126,12 @@ export function waitMinutes(mins: number, t?: Test): Promise<void> {
     return waitMs(mins * 60 * 1000, t);
 }
 
-// Helper function for cleaning up an agent processe and passing/failing a test
+// Helper function for cleaning up an agent and passing/failing a test
 export function cleanup(t: Test, agent: ExternalProcessAgent, err?: Error): Promise<void> {
     if (!agent) { t.end(err); return Promise.resolve(); }
-    return agent.getProcess()
-        .then(process => process.kill())
-        .then(() => t.end(err));
+    return agent.disconnect()
+        .then(() => t.end(err))
+        .catch(() => t.end(err));
 }
 
 // Helper that waits for agent buffer to flush

--- a/test/winston.e2e.ts
+++ b/test/winston.e2e.ts
@@ -66,7 +66,7 @@ test("Scout inherits winston logger level", t => {
                 ],
             });
             const logFn = buildWinstonLogFn(logger);
-            scoutConfig = {allowShutdown: true, monitor: true};
+            scoutConfig = {monitor: true};
             t.equals(scoutConfig.logLevel, undefined, "scout log level is initially undefined");
             return TestUtil.buildTestScoutInstanceWithMock(scoutConfig, {logFn});
         })


### PR DESCRIPTION
## Problem

Two related bugs in cluster deployments, both rooted in the same design flaw — workers treating the core-agent as a child process they own:

**Always-spawns bug**: `start()` called `peerRunning()` to check if a socket existed, but then called `startProcess()` unconditionally regardless of the result. In a cluster, every worker that initialised Scout would spawn a new core-agent binary even if one was already running. The second agent would fail to bind the port and exit immediately, leaving that worker with a dead `detachedProcess` reference.

**Cluster-shutdown bug (issue #117)**: `stopProcess()` sent `SIGKILL` to the core-agent process group and removed the socket. When any worker called `scout.shutdown()` (including on crash/unhandled rejection with `allowShutdown: true`), it killed the shared core-agent for every other worker in the cluster. Other workers continued serving HTTP requests normally (Scout's send path is async and fire-and-forget after `onFinished`), but all APM data was silently dropped until a replacement core-agent spawned — exactly the window when visibility is most needed.

## Fix

Mirrors the approach used by the Python agent (`scout_apm_python/src/scout_apm/core/agent/manager.py`):

- **`--daemonize true`** added to the binary args. The binary forks itself into a true background daemon; the spawned process exits immediately. No PID is retained by the worker.
- **`start()` returns early** when `peerRunning()` is true — the worker connects to the existing daemon rather than spawning another.
- **`stopProcess()` is now a no-op.** Workers have no PID to kill and should not attempt to manage the daemon's lifecycle.
- **`allowShutdown` branch removed** from `Scout.shutdown()` — disconnect (draining the socket pool) is the full extent of what a worker does on shutdown.
- Removed `getProcess()` and `detachedProcess` field entirely.

## Test changes

- `test/util.ts` `cleanup()`: calls `agent.disconnect()` instead of `process.kill()`
- Updated two tests that relied on `getProcess()` to reflect the new behaviour

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>