### PR TITLE
feat(express): walk nested express.Router() stacks for route path resolution

### DIFF
--- a/dist/lib/express.d.ts
+++ b/dist/lib/express.d.ts
@@ -22,8 +22,8 @@ export declare function listExpressEndpoints(app: any): EndpointInfo[];
 export interface ApplicationWithScout {
     scout?: Scout;
 }
-declare type ExpressMiddleware = (req: any, res: any, next: () => void) => void;
-declare type ExpressErrorMiddleware = (err: any, req: any, res: any, next: (err?: any) => void) => void;
+type ExpressMiddleware = (req: any, res: any, next: () => void) => void;
+type ExpressErrorMiddleware = (err: any, req: any, res: any, next: (err?: any) => void) => void;
 export interface ExpressMiddlewareOptions {
     config?: Partial<ScoutConfiguration>;
     logFn?: LogFn;
@@ -37,7 +37,7 @@ export interface ExpressScoutInfo {
     request?: ScoutRequest;
     rootSpan?: ScoutSpan;
 }
-export declare type ExpressRequestWithScout = Request & ExpressScoutInfo;
+export type ExpressRequestWithScout = Request & ExpressScoutInfo;
 /**
  * Middleware for using scout, this should be
  * attached to the application object using app.use(...)

--- a/dist/lib/express.js
+++ b/dist/lib/express.js
@@ -116,6 +116,58 @@ function parseQueueTimeNS(value) {
 }
 const ROUTE_INFO_LOOKUP = {};
 /**
+ * Recursively find the full route path for a URL within a router layer stack.
+ * Handles Express 4 (regexp) and Express 5 (match function) layer formats,
+ * and recurses into nested express.Router() instances.
+ *
+ * Each nested Router's match() operates on the URL relative to its mount point,
+ * so we try stripping 1..N leading segments until a sub-stack match is found.
+ */
+function findRoutePathInStack(stack, url, mountPrefix) {
+    const segments = url.split("/").filter(Boolean);
+    for (const layer of stack) {
+        if (!layer) {
+            continue;
+        }
+        if (layer.route) {
+            let isMatch = false;
+            if (layer.regexp) {
+                isMatch = layer.regexp.test(url);
+            }
+            else if (typeof layer.match === "function") {
+                isMatch = !!layer.match(url);
+            }
+            if (isMatch) {
+                // Avoid double-slash when a sub-router root ('/') is appended to a non-empty prefix
+                const suffix = layer.route.path === "/" && mountPrefix !== "" ? "" : layer.route.path;
+                return mountPrefix + suffix;
+            }
+        }
+        else if (layer.name === "router" && layer.handle && layer.handle.stack) {
+            let routerMatches = false;
+            if (layer.regexp) {
+                routerMatches = layer.regexp.test(url);
+            }
+            else if (typeof layer.match === "function") {
+                routerMatches = !!layer.match(url);
+            }
+            if (!routerMatches) {
+                continue;
+            }
+            // Strip 1..N leading segments to derive the sub-URL relative to the nested router
+            for (let i = 1; i <= segments.length; i++) {
+                const nestedMount = mountPrefix + "/" + segments.slice(0, i).join("/");
+                const nestedUrl = segments.slice(i).length > 0 ? "/" + segments.slice(i).join("/") : "/";
+                const result = findRoutePathInStack(layer.handle.stack, nestedUrl, nestedMount);
+                if (result) {
+                    return result;
+                }
+            }
+        }
+    }
+    return null;
+}
+/**
  * Middleware for using scout, this should be
  * attached to the application object using app.use(...)
  *
@@ -216,6 +268,15 @@ function scoutMiddleware(opts) {
         // (for the request name, e.x. "Controller/GET <some path>")
         if (matchedRouteMiddleware) {
             routePath = matchedRouteMiddleware.route.path;
+        }
+        // If still no match, walk nested express.Router() stacks recursively.
+        // This handles routes mounted via app.use('/prefix', router) that are invisible
+        // to the top-level stack scan (which only looks at layers with layer.route).
+        if (!routePath && appRouter && appRouter.stack) {
+            const nestedPath = findRoutePathInStack(appRouter.stack, preQueryUrl, "");
+            if (nestedPath) {
+                routePath = nestedPath;
+            }
         }
         // If we get to this point and matchedRouteMiddleware is still empty/missing
         // we're likely in the case of a nested express.Router and cannot rely on

--- a/dist/lib/express.js
+++ b/dist/lib/express.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.errorMiddleware = exports.scoutMiddleware = exports.listExpressEndpoints = void 0;
 const onFinished = require("on-finished");
 const async_hooks_1 = require("async_hooks");
 const types_1 = require("./types");
@@ -127,23 +128,23 @@ function scoutMiddleware(opts) {
     const commonRouteMiddlewares = [];
     // Build configuration overrides
     const overrides = opts && opts.config ? opts.config : {};
-    const config = types_1.buildScoutConfiguration(overrides);
+    const config = (0, types_1.buildScoutConfiguration)(overrides);
     const options = {
         logFn: opts && opts.logFn ? opts.logFn : undefined,
         statisticsIntervalMS: opts && opts.statisticsIntervalMS ? opts.statisticsIntervalMS : undefined,
     };
     // Set the last used configurations
-    global_1.setGlobalLastUsedConfiguration(config);
-    global_1.setGlobalLastUsedOptions(options);
+    (0, global_1.setGlobalLastUsedConfiguration)(config);
+    (0, global_1.setGlobalLastUsedOptions)(options);
     return (req, res, next) => {
         const requestStartTimeNS = getNanoTime();
         // If there is no global scout instance yet and no scout instance just go to next middleware immediately
-        const scout = opts && opts.scout ? opts.scout : req.app.scout || global_1.getActiveGlobalScoutInstance();
+        const scout = opts && opts.scout ? opts.scout : req.app.scout || (0, global_1.getActiveGlobalScoutInstance)();
         // Build a closure that installs scout (and waits on it)
         // depending on whether waitForScoutSetup is set we will run this in the background or inline
         const setupScout = () => {
             // If app doesn't already have a scout instance *and* no active global one is present, create one
-            return global_1.getOrCreateActiveGlobalScoutInstance(config, options)
+            return (0, global_1.getOrCreateActiveGlobalScoutInstance)(config, options)
                 .then(scout => req.app.scout = scout);
         };
         const waitForScoutSetup = opts && opts.waitForScoutSetup;
@@ -184,12 +185,18 @@ function scoutMiddleware(opts) {
             // Find routes that match the current URL
             matchedRouteMiddleware = appRouter.stack
                 .filter((middleware) => {
-                // We can recognize a middleware as a route if .route & .regexp are present
-                if (!middleware || !middleware.route || !middleware.regexp) {
+                if (!middleware || !middleware.route) {
                     return false;
                 }
-                // Check if the URL matches the route
-                const isMatch = middleware.regexp.test(preQueryUrl);
+                // Express v4: layer has a pre-built regexp
+                // Express v5: layer has a match() method instead
+                let isMatch = false;
+                if (middleware.regexp) {
+                    isMatch = middleware.regexp.test(preQueryUrl);
+                }
+                else if (typeof middleware.match === "function") {
+                    isMatch = middleware.match(preQueryUrl);
+                }
                 // Add matches in the hope that common routes will be faster than searching everything
                 if (isMatch) {
                     commonRouteMiddlewares.push(middleware);
@@ -218,7 +225,7 @@ function scoutMiddleware(opts) {
                     listExpressEndpoints(req.app)
                         .forEach(r => {
                         // Enrich endpoint list with regexes for the full match
-                        r.regex = path_to_regexp_1.pathToRegexp(r.path);
+                        r.regex = (0, path_to_regexp_1.pathToRegexp)(r.path);
                         ROUTE_INFO_LOOKUP[r.path] = Object.assign(Object.assign({}, r), { middleware: r.middleware || [], regex: r.regex });
                     });
                     // Search again after adding to the cache

--- a/dist/lib/express.js
+++ b/dist/lib/express.js
@@ -170,7 +170,15 @@ function scoutMiddleware(opts) {
         // The query of the URL needs to be  stripped before attempting to test it against express regexps
         // i.e. all route regexps end in /..\?$/
         const preQueryUrl = reqUrl.split("?")[0];
-        let matchedRouteMiddleware = commonRouteMiddlewares.find((m) => m.regexp.test(preQueryUrl));
+        let matchedRouteMiddleware = commonRouteMiddlewares.find((m) => {
+            if (m.regexp) {
+                return m.regexp.test(preQueryUrl);
+            }
+            if (typeof m.match === "function") {
+                return m.match(preQueryUrl);
+            }
+            return false;
+        });
         // If we couldn't find a route in the ones that have worked before,
         // then we have to search the router stack
         // Express 4 uses _router; Express 5 uses router (a getter that throws on Express 4)

--- a/dist/test/express.e2e.js
+++ b/dist/test/express.e2e.js
@@ -13,7 +13,7 @@ const getNanoTime = require("nano-time");
 const BigNumber = require("big-number");
 const global_1 = require("../lib/global");
 const TEST_OPTS = { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS };
-lib_1.setupRequireIntegrations(["pug", "ejs", "mustache"]);
+(0, lib_1.setupRequireIntegrations)(["pug", "ejs", "mustache"]);
 // Shared mock agent for all express tests
 const sharedMock = new mock_agent_1.MockAgent();
 function withMock(extras = {}) {
@@ -28,8 +28,8 @@ test("setup: start shared mock agent", t => {
 });
 test("Simple operation", t => {
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleExpressApp(express_1.scoutMiddleware({
-        config: types_1.buildScoutConfiguration(withMock({
+    const app = TestUtil.simpleExpressApp((0, express_1.scoutMiddleware)({
+        config: (0, types_1.buildScoutConfiguration)(withMock({
             allowShutdown: true,
             monitor: true,
         })),
@@ -73,8 +73,8 @@ test("Simple operation", t => {
 });
 test("Dynamic segment routes (uses global instance)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
-        config: types_1.buildScoutConfiguration(withMock({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
+        config: (0, types_1.buildScoutConfiguration)(withMock({
             allowShutdown: true,
             monitor: true,
         })),
@@ -131,8 +131,8 @@ test("Dynamic segment routes (uses global instance)", { timeout: TestUtil.EXPRES
 });
 test("Application which errors (uses global scout instance)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleErrorApp(express_1.scoutMiddleware({
-        config: types_1.buildScoutConfiguration(withMock({
+    const app = TestUtil.simpleErrorApp((0, express_1.scoutMiddleware)({
+        config: (0, types_1.buildScoutConfiguration)(withMock({
             allowShutdown: true,
             monitor: true,
         })),
@@ -157,13 +157,13 @@ test("Application which errors (uses global scout instance)", { timeout: TestUti
 });
 test("express ignores a path (exact path, with dynamic segments)", TEST_OPTS, t => {
     const path = "/dynamic/:segment";
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
         ignore: [path],
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -185,13 +185,13 @@ test("express ignores a path (exact path, with dynamic segments)", TEST_OPTS, t 
 });
 test("express ignores a path (exact path, static)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     const path = "/";
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
         ignore: [path],
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -214,13 +214,13 @@ test("express ignores a path (exact path, static)", { timeout: TestUtil.EXPRESS_
 test("express ignores a path (prefix, with dynamic segments)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     const path = "/dynamic/:segment";
     const prefix = "/dynamic";
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
         ignore: [prefix],
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -244,13 +244,13 @@ test("express ignores a path (prefix, with dynamic segments)", { timeout: TestUt
 test("express ignores a path (prefix, static)", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
     const path = "/echo-by-post";
     const prefix = "/echo";
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
         ignore: [prefix],
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -273,12 +273,12 @@ test("express ignores a path (prefix, static)", { timeout: TestUtil.EXPRESS_TEST
         .catch(err => TestUtil.shutdownScout(t, scout, err));
 });
 test("URI params are filtered", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -309,13 +309,13 @@ test("URI params are filtered", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t
         .catch(err => TestUtil.shutdownScout(t, scout, err));
 });
 test("URI filtered down to path", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
         uriReporting: types_1.URIReportingLevel.Path,
     })));
     // Create an application and setup scout middleware
-    const app = TestUtil.simpleDynamicSegmentExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleDynamicSegmentExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -347,12 +347,12 @@ test("URI filtered down to path", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS },
 });
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("Pug integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
     })));
     // Create an application that's set up to use pug templating
-    const app = TestUtil.simpleHTML5BoilerplateApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleHTML5BoilerplateApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -394,12 +394,12 @@ test("Pug integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t =
 });
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("ejs integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
     })));
     // Create an application that's set up to use ejs templating
-    const app = TestUtil.simpleHTML5BoilerplateApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleHTML5BoilerplateApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -441,12 +441,12 @@ test("ejs integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t =
 });
 // https://github.com/scoutapp/scout_apm_node/issues/82
 test("mustache integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
     })));
     // Create an application that's set up to use mustache templating
-    const app = TestUtil.simpleHTML5BoilerplateApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleHTML5BoilerplateApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -488,12 +488,12 @@ test("mustache integration works", { timeout: TestUtil.EXPRESS_TEST_TIMEOUT_MS }
 });
 // https://github.com/scoutapp/scout_apm_node/issues/129
 test("Nested spans on the top level controller have parent ID specified", TEST_OPTS, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
     })));
     // Create an application that's set up to do a simple instrumentation
-    const app = TestUtil.simpleInstrumentApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleInstrumentApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -535,12 +535,12 @@ test("Nested spans on the top level controller have parent ID specified", TEST_O
 });
 // https://github.com/scoutapp/scout_apm_node/issues/150
 test("Unknown routes should not be recorded", TEST_OPTS, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
     })));
     // Create an application that's set up to do a simple instrumentation
-    const app = TestUtil.simpleExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -567,12 +567,12 @@ test("Unknown routes should not be recorded", TEST_OPTS, t => {
 });
 // https://github.com/scoutapp/scout_apm_node/issues/68
 test("Request queue time should be recorded", TEST_OPTS, t => {
-    const scout = new scout_1.Scout(types_1.buildScoutConfiguration(withMock({
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
         allowShutdown: true,
         monitor: true,
     })));
     // Create an application that's set up to do a simple instrumentation
-    const app = TestUtil.simpleExpressApp(express_1.scoutMiddleware({
+    const app = TestUtil.simpleExpressApp((0, express_1.scoutMiddleware)({
         scout,
         requestTimeoutMs: 0,
         waitForScoutSetup: true,
@@ -608,9 +608,73 @@ test("Request queue time should be recorded", TEST_OPTS, t => {
     })
         .catch(err => TestUtil.shutdownScout(t, scout, err));
 });
+test("express Router() routes are traced (one level nesting)", TEST_OPTS, t => {
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
+        allowShutdown: true,
+        monitor: true,
+    })));
+    const app = TestUtil.simpleRouterExpressApp((0, express_1.scoutMiddleware)({
+        scout,
+        requestTimeoutMs: 0,
+        waitForScoutSetup: true,
+    }));
+    const expectedOperation = "Controller/GET /api/echo/:name";
+    const listener = (data) => {
+        if (!data || !data.request) {
+            return;
+        }
+        const spans = data.request.getChildSpansSync();
+        if (!spans || spans.length === 0) {
+            return;
+        }
+        const top = spans[0];
+        if (!top.operation.startsWith("Controller")) {
+            return;
+        }
+        t.equals(top.operation, expectedOperation, "router route has correct operation name");
+        scout.removeListener(types_1.ScoutEvent.RequestSent, listener);
+        TestUtil.shutdownScout(t, scout).catch(err => TestUtil.shutdownScout(t, scout, err));
+    };
+    scout.on(types_1.ScoutEvent.RequestSent, listener);
+    scout.setup()
+        .then(() => request(app).get("/api/echo/alice").expect("Content-Type", /json/).expect(200))
+        .catch(err => TestUtil.shutdownScout(t, scout, err));
+});
+test("express Router() routes are traced (two levels nesting)", TEST_OPTS, t => {
+    const scout = new scout_1.Scout((0, types_1.buildScoutConfiguration)(withMock({
+        allowShutdown: true,
+        monitor: true,
+    })));
+    const app = TestUtil.simpleRouterExpressApp((0, express_1.scoutMiddleware)({
+        scout,
+        requestTimeoutMs: 0,
+        waitForScoutSetup: true,
+    }));
+    const expectedOperation = "Controller/GET /api/nested/deep/:id";
+    const listener = (data) => {
+        if (!data || !data.request) {
+            return;
+        }
+        const spans = data.request.getChildSpansSync();
+        if (!spans || spans.length === 0) {
+            return;
+        }
+        const top = spans[0];
+        if (!top.operation.startsWith("Controller")) {
+            return;
+        }
+        t.equals(top.operation, expectedOperation, "nested router route has correct operation name");
+        scout.removeListener(types_1.ScoutEvent.RequestSent, listener);
+        TestUtil.shutdownScout(t, scout).catch(err => TestUtil.shutdownScout(t, scout, err));
+    };
+    scout.on(types_1.ScoutEvent.RequestSent, listener);
+    scout.setup()
+        .then(() => request(app).get("/api/nested/deep/42").expect("Content-Type", /json/).expect(200))
+        .catch(err => TestUtil.shutdownScout(t, scout, err));
+});
 // Cleanup the global isntance(s) that get created
 test("Shutdown the global instance", t => {
-    const inst = global_1.getActiveGlobalScoutInstance();
+    const inst = (0, global_1.getActiveGlobalScoutInstance)();
     if (inst) {
         return TestUtil.shutdownScout(t, inst);
     }

--- a/dist/test/util.d.ts
+++ b/dist/test/util.d.ts
@@ -1,4 +1,7 @@
 /// <reference types="node" />
+/// <reference types="node" />
+/// <reference types="node" />
+/// <reference types="node" />
 import * as net from "net";
 import { Application } from "express";
 import { ChildProcess } from "child_process";
@@ -27,6 +30,7 @@ export declare function shutdownScout(t: Test, scout: Scout, err?: Error): Promi
 export declare function shutdownScoutAndMock(t: Test, scout: Scout, mockAgent: MockAgent, err?: Error): Promise<void>;
 export declare function simpleExpressApp(middleware: any, delayMs?: number): Application;
 export declare function simpleDynamicSegmentExpressApp(middleware: any, delayMs?: number): Application;
+export declare function simpleRouterExpressApp(middleware: any): Application;
 export declare function simpleErrorApp(middleware: any, delayMs?: number): Application;
 export declare function simpleHTML5BoilerplateApp(middleware: any, templateEngine: "pug" | "ejs" | "mustache"): Application;
 export declare function simpleInstrumentApp(middleware: any): Application;
@@ -98,7 +102,7 @@ export declare function stopContainerizedInstanceTest(test: any, provider: () =>
 export declare function stopContainerizedPostgresTest(test: any, provider: () => ContainerAndOpts | null): void;
 export declare function makeConnectedPGClient(provider: () => ContainerAndOpts | null): Promise<Client>;
 export declare function makePGConnectionString(provider: () => ContainerAndOpts | null): Promise<string>;
-declare type ServerShutdownFn = () => void;
+type ServerShutdownFn = () => void;
 export declare function createClientCollectingServer(): [net.Server, ServerShutdownFn];
 export declare function startContainerizedMySQLTest(test: any, cb: (cao: ContainerAndOpts) => void, opts?: {
     containerEnv?: object;

--- a/dist/test/util.js
+++ b/dist/test/util.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.minimal = exports.makeConnectedMySQL2Connection = exports.makeConnectedMySQLConnection = exports.stopContainerizedMySQLTest = exports.startContainerizedMySQLTest = exports.createClientCollectingServer = exports.makePGConnectionString = exports.makeConnectedPGClient = exports.stopContainerizedPostgresTest = exports.stopContainerizedInstanceTest = exports.startContainerizedPostgresTest = exports.killContainer = exports.startContainer = exports.TestContainerStartOpts = exports.buildTestScoutInstanceWithMock = exports.getOrStartSharedMock = exports.buildTestScoutInstance = exports.buildCoreAgentSocketResponse = exports.testConfigurationOverlay = exports.appWithRouterGET = exports.queryAndRenderRandomNumbers = exports.appWithHTTPProxyMiddleware = exports.appWithGETSynchronousError = exports.simpleInstrumentApp = exports.simpleHTML5BoilerplateApp = exports.simpleErrorApp = exports.simpleRouterExpressApp = exports.simpleDynamicSegmentExpressApp = exports.simpleExpressApp = exports.shutdownScoutAndMock = exports.shutdownScout = exports.waitForAgentBufferFlush = exports.cleanup = exports.waitMinutes = exports.waitMs = exports.initializeAgent = exports.bootstrapExternalProcessAgent = exports.MEMORY_LEAK_TEST_TIMEOUT_MS = exports.DASHBOARD_SEND_TIMEOUT_MS = exports.MYSQL_TEST_TIMEOUT_MS = exports.PG_TEST_TIMEOUT_MS = exports.EXPRESS_TEST_TIMEOUT_MS = void 0;
 const tslib_1 = require("tslib");
 const path = require("path");
 const tmp = require("tmp-promise");
@@ -172,6 +173,27 @@ function simpleDynamicSegmentExpressApp(middleware, delayMs = 0) {
     return app;
 }
 exports.simpleDynamicSegmentExpressApp = simpleDynamicSegmentExpressApp;
+// An express application with routes via express.Router() mounted at /api.
+// Used to verify that scoutMiddleware traces Router-based routes without needing
+// the express integration shim.
+//   GET /api/echo/:name        — one level deep
+//   GET /api/nested/deep/:id   — two levels deep (router inside router)
+function simpleRouterExpressApp(middleware) {
+    const app = express();
+    app.use(middleware);
+    const router = express.Router();
+    router.get("/echo/:name", (req, res) => {
+        res.json({ status: "success", name: req.params.name });
+    });
+    const nested = express.Router();
+    nested.get("/deep/:id", (req, res) => {
+        res.json({ status: "success", id: req.params.id });
+    });
+    router.use("/nested", nested);
+    app.use("/api", router);
+    return app;
+}
+exports.simpleRouterExpressApp = simpleRouterExpressApp;
 // An express application which errors on the /
 function simpleErrorApp(middleware, delayMs = 0) {
     const app = express();
@@ -190,7 +212,7 @@ function simpleHTML5BoilerplateApp(middleware, templateEngine) {
         app.engine("mustache", require("mustache-express")());
     }
     // Expect all the views to be in the same fixtures/files path
-    const VIEWS_DIR = path.join(app_root_dir_1.get(), "test/fixtures/files");
+    const VIEWS_DIR = path.join((0, app_root_dir_1.get)(), "test/fixtures/files");
     app.set("views", VIEWS_DIR);
     app.set("view engine", templateEngine);
     app.get("/", (req, res) => {
@@ -251,7 +273,7 @@ function queryAndRenderRandomNumbers(middleware, templateEngine, dbClient) {
         app.engine("mustache", require("mustache-express")());
     }
     // Expect all the views to be in the same fixtures/files path
-    const VIEWS_DIR = path.join(app_root_dir_1.get(), "test/fixtures/files");
+    const VIEWS_DIR = path.join((0, app_root_dir_1.get)(), "test/fixtures/files");
     app.set("views", VIEWS_DIR);
     app.set("view engine", templateEngine);
     app.get("/", (req, res) => {
@@ -298,9 +320,9 @@ exports.appWithRouterGET = appWithRouterGET;
 // Test that a given variable is effectively overlaid in the configuration
 function testConfigurationOverlay(t, opts) {
     const { appKey, envValue, expectedValue } = opts;
-    const envKey = types_1.convertCamelCaseToEnvVar(appKey);
+    const envKey = (0, types_1.convertCamelCaseToEnvVar)(appKey);
     const envValueIsSet = envKey in process.env;
-    const defaultConfig = types_1.buildScoutConfiguration();
+    const defaultConfig = (0, types_1.buildScoutConfiguration)();
     t.assert(defaultConfig, "defaultConfig was generated");
     // Only perform this check if we're not currently overriding the value in ENV *during* this test
     // it won't be the default, because we've set it to be so
@@ -310,7 +332,7 @@ function testConfigurationOverlay(t, opts) {
     // Set key at the application level
     const appConfig = {};
     appConfig[appKey] = expectedValue;
-    const appOnlyConfig = types_1.buildScoutConfiguration(appConfig);
+    const appOnlyConfig = (0, types_1.buildScoutConfiguration)(appConfig);
     t.assert(appOnlyConfig, "appOnlyConfig was generated");
     // Only perform this check if we're not currently overriding the value in ENV *during* this test
     // ENV overrides the app so it won't be the app value
@@ -323,7 +345,7 @@ function testConfigurationOverlay(t, opts) {
     process.env[envKey] = envValue;
     // FUTURE: we could also *simulate* process.env here by passing in {env: {...}} to buildScoutConfiguration
     // since we're not trying to do parallel tests yet (env will be changed and reset serially), it's fine
-    const envOverrideConfig = types_1.buildScoutConfiguration(appConfig);
+    const envOverrideConfig = (0, types_1.buildScoutConfiguration)(appConfig);
     t.assert(envOverrideConfig, "envOverrideConfig was generated");
     t.deepEquals(envOverrideConfig[appKey], expectedValue, `config [${appKey}] matches app value when set by app`);
     // Reset the env value
@@ -346,7 +368,7 @@ function buildCoreAgentSocketResponse(json) {
 }
 exports.buildCoreAgentSocketResponse = buildCoreAgentSocketResponse;
 function buildTestScoutInstance(configOverride, options) {
-    const cfg = types_1.buildScoutConfiguration(Object.assign({ allowShutdown: true, monitor: true }, configOverride));
+    const cfg = (0, types_1.buildScoutConfiguration)(Object.assign({ allowShutdown: true, monitor: true }, configOverride));
     return new scout_1.Scout(cfg, options);
 }
 exports.buildTestScoutInstance = buildTestScoutInstance;
@@ -366,7 +388,7 @@ function buildTestScoutInstanceWithMock(configOverride, options) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
         const mockAgent = new mock_agent_1.MockAgent();
         yield mockAgent.start();
-        const cfg = types_1.buildScoutConfiguration(Object.assign({
+        const cfg = (0, types_1.buildScoutConfiguration)(Object.assign({
             allowShutdown: true,
             monitor: true,
             coreAgentLaunch: false,
@@ -418,7 +440,7 @@ class TestContainerStartOpts {
         }
         // Generate a random container name if one wasn't provided
         if (!this.containerName) {
-            this.containerName = `test-${this.imageName}-${randomstring_1.generate(5)}`;
+            this.containerName = `test-${this.imageName}-${(0, randomstring_1.generate)(5)}`;
         }
     }
     imageWithTag() {
@@ -460,7 +482,7 @@ function startContainer(t, optOverrides) {
     ];
     // Spawn the docker container
     t.comment(`spawning container [${opts.imageName}:${opts.tagName}] with name [${opts.containerName}]...`);
-    const containerProcess = child_process_1.spawn(opts.dockerBinPath, args, { detached: true, stdio: "pipe" });
+    const containerProcess = (0, child_process_1.spawn)(opts.dockerBinPath, args, { detached: true, stdio: "pipe" });
     opts.setExecutedStartCommand(`${opts.dockerBinPath} ${args.join(" ")}`);
     let resolved = false;
     let stdoutListener;
@@ -473,7 +495,7 @@ function startContainer(t, optOverrides) {
         if (expected.times && expected.times <= 0) {
             return () => reject(new Error(`[${type}] invalid waitFor: expected.times <= 0`));
         }
-        let times = (_a = expected.times, (_a !== null && _a !== void 0 ? _a : 1));
+        let times = (_a = expected.times) !== null && _a !== void 0 ? _a : 1;
         return (line) => {
             line = line.toString();
             if (!line.includes(expected.phrase)) {
@@ -568,7 +590,7 @@ function startContainer(t, optOverrides) {
             resolve({ containerProcess, opts });
         });
     });
-    return promise_timeout_1.timeout(promise, opts.startTimeoutMs)
+    return (0, promise_timeout_1.timeout)(promise, opts.startTimeoutMs)
         .catch(err => {
         // If we timed out clean up some waiting stuff, shutdown the process
         // since none of the listeners may have triggered, clean them up
@@ -591,13 +613,13 @@ function killContainer(t, opts) {
     const args = ["kill", opts.containerName];
     // Spawn the docker container
     t.comment(`attempting to kill [${opts.containerName}]...`);
-    const dockerKillProcess = child_process_1.spawn(opts.dockerBinPath, args, { detached: true, stdio: "ignore" });
+    const dockerKillProcess = (0, child_process_1.spawn)(opts.dockerBinPath, args, { detached: true, stdio: "ignore" });
     const promise = new Promise((resolve, reject) => {
         dockerKillProcess.on("close", code => {
             resolve(code);
         });
     });
-    return promise_timeout_1.timeout(promise, opts.killTimeoutMs);
+    return (0, promise_timeout_1.timeout)(promise, opts.killTimeoutMs);
 }
 exports.killContainer = killContainer;
 const POSTGRES_IMAGE_NAME = "postgres";
@@ -796,7 +818,7 @@ function makeConnectedMySQLConnection(provider) {
         return Promise.reject(new Error("no CAO in provider"));
     }
     const port = cao.opts.portBinding[3306];
-    const conn = mysql_1.createConnection({
+    const conn = (0, mysql_1.createConnection)({
         user: "root",
         password: "mysql",
         host: "localhost",
@@ -819,7 +841,7 @@ function makeConnectedMySQL2Connection(provider) {
     if (!cao) {
         return Promise.reject(new Error("no CAO in provider"));
     }
-    const conn = mysql2_1.createConnection({
+    const conn = (0, mysql2_1.createConnection)({
         user: "root",
         password: "mysql",
         host: "localhost",

--- a/lib/express.ts
+++ b/lib/express.ts
@@ -248,7 +248,11 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
         // The query of the URL needs to be  stripped before attempting to test it against express regexps
         // i.e. all route regexps end in /..\?$/
         const preQueryUrl = reqUrl.split("?")[0];
-        let matchedRouteMiddleware = commonRouteMiddlewares.find((m: any) => m.regexp.test(preQueryUrl));
+        let matchedRouteMiddleware = commonRouteMiddlewares.find((m: any) => {
+            if (m.regexp) { return m.regexp.test(preQueryUrl); }
+            if (typeof m.match === "function") { return m.match(preQueryUrl); }
+            return false;
+        });
 
         // If we couldn't find a route in the ones that have worked before,
         // then we have to search the router stack

--- a/lib/express.ts
+++ b/lib/express.ts
@@ -184,6 +184,44 @@ interface EndpointListingItem {
 const ROUTE_INFO_LOOKUP: {[key: string]: EndpointListingItem} = {};
 
 /**
+ * Recursively find the full route path for a URL within a router layer stack.
+ * Handles Express 4 (regexp) and Express 5 (match function) layer formats,
+ * and recurses into nested express.Router() instances.
+ *
+ * Each nested Router's match() operates on the URL relative to its mount point,
+ * so we try stripping 1..N leading segments until a sub-stack match is found.
+ */
+function findRoutePathInStack(stack: any[], url: string, mountPrefix: string): string | null {
+    const segments = url.split("/").filter(Boolean);
+    for (const layer of stack) {
+        if (!layer) { continue; }
+        if (layer.route) {
+            let isMatch = false;
+            if (layer.regexp) { isMatch = layer.regexp.test(url); }
+            else if (typeof layer.match === "function") { isMatch = !!layer.match(url); }
+            if (isMatch) {
+                // Avoid double-slash when a sub-router root ('/') is appended to a non-empty prefix
+                const suffix = layer.route.path === "/" && mountPrefix !== "" ? "" : layer.route.path;
+                return mountPrefix + suffix;
+            }
+        } else if (layer.name === "router" && layer.handle && layer.handle.stack) {
+            let routerMatches = false;
+            if (layer.regexp) { routerMatches = layer.regexp.test(url); }
+            else if (typeof layer.match === "function") { routerMatches = !!layer.match(url); }
+            if (!routerMatches) { continue; }
+            // Strip 1..N leading segments to derive the sub-URL relative to the nested router
+            for (let i = 1; i <= segments.length; i++) {
+                const nestedMount = mountPrefix + "/" + segments.slice(0, i).join("/");
+                const nestedUrl = segments.slice(i).length > 0 ? "/" + segments.slice(i).join("/") : "/";
+                const result = findRoutePathInStack(layer.handle.stack, nestedUrl, nestedMount);
+                if (result) { return result; }
+            }
+        }
+    }
+    return null;
+}
+
+/**
  * Middleware for using scout, this should be
  * attached to the application object using app.use(...)
  *
@@ -287,6 +325,14 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
         // (for the request name, e.x. "Controller/GET <some path>")
         if (matchedRouteMiddleware) {
             routePath = matchedRouteMiddleware.route.path;
+        }
+
+        // If still no match, walk nested express.Router() stacks recursively.
+        // This handles routes mounted via app.use('/prefix', router) that are invisible
+        // to the top-level stack scan (which only looks at layers with layer.route).
+        if (!routePath && appRouter && appRouter.stack) {
+            const nestedPath = findRoutePathInStack(appRouter.stack, preQueryUrl, "");
+            if (nestedPath) { routePath = nestedPath; }
         }
 
         // If we get to this point and matchedRouteMiddleware is still empty/missing

--- a/lib/express.ts
+++ b/lib/express.ts
@@ -261,11 +261,16 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
             // Find routes that match the current URL
             matchedRouteMiddleware = appRouter.stack
                 .filter((middleware: any) => {
-                    // We can recognize a middleware as a route if .route & .regexp are present
-                    if (!middleware || !middleware.route || !middleware.regexp) { return false; }
+                    if (!middleware || !middleware.route) { return false; }
 
-                    // Check if the URL matches the route
-                    const isMatch = middleware.regexp.test(preQueryUrl);
+                    // Express v4: layer has a pre-built regexp
+                    // Express v5: layer has a match() method instead
+                    let isMatch = false;
+                    if (middleware.regexp) {
+                        isMatch = middleware.regexp.test(preQueryUrl);
+                    } else if (typeof middleware.match === "function") {
+                        isMatch = middleware.match(preQueryUrl);
+                    }
 
                     // Add matches in the hope that common routes will be faster than searching everything
                     if (isMatch) { commonRouteMiddlewares.push(middleware); }

--- a/test/express.e2e.ts
+++ b/test/express.e2e.ts
@@ -763,6 +763,72 @@ test("Request queue time should be recorded", TEST_OPTS, t => {
         .catch(err => TestUtil.shutdownScout(t, scout, err));
 });
 
+test("express Router() routes are traced (one level nesting)", TEST_OPTS, t => {
+    const scout = new Scout(buildScoutConfiguration(withMock({
+        allowShutdown: true,
+        monitor: true,
+    })));
+
+    const app: Application & ApplicationWithScout = TestUtil.simpleRouterExpressApp(scoutMiddleware({
+        scout,
+        requestTimeoutMs: 0,
+        waitForScoutSetup: true,
+    })) as any;
+
+    const expectedOperation = "Controller/GET /api/echo/:name";
+
+    const listener = (data: ScoutEventRequestSentData) => {
+        if (!data || !data.request) { return; }
+        const spans = data.request.getChildSpansSync();
+        if (!spans || spans.length === 0) { return; }
+        const top = spans[0];
+        if (!top.operation.startsWith("Controller")) { return; }
+
+        t.equals(top.operation, expectedOperation, "router route has correct operation name");
+        scout.removeListener(ScoutEvent.RequestSent, listener);
+        TestUtil.shutdownScout(t, scout).catch(err => TestUtil.shutdownScout(t, scout, err));
+    };
+
+    scout.on(ScoutEvent.RequestSent, listener);
+
+    scout.setup()
+        .then(() => request(app).get("/api/echo/alice").expect("Content-Type", /json/).expect(200))
+        .catch(err => TestUtil.shutdownScout(t, scout, err));
+});
+
+test("express Router() routes are traced (two levels nesting)", TEST_OPTS, t => {
+    const scout = new Scout(buildScoutConfiguration(withMock({
+        allowShutdown: true,
+        monitor: true,
+    })));
+
+    const app: Application & ApplicationWithScout = TestUtil.simpleRouterExpressApp(scoutMiddleware({
+        scout,
+        requestTimeoutMs: 0,
+        waitForScoutSetup: true,
+    })) as any;
+
+    const expectedOperation = "Controller/GET /api/nested/deep/:id";
+
+    const listener = (data: ScoutEventRequestSentData) => {
+        if (!data || !data.request) { return; }
+        const spans = data.request.getChildSpansSync();
+        if (!spans || spans.length === 0) { return; }
+        const top = spans[0];
+        if (!top.operation.startsWith("Controller")) { return; }
+
+        t.equals(top.operation, expectedOperation, "nested router route has correct operation name");
+        scout.removeListener(ScoutEvent.RequestSent, listener);
+        TestUtil.shutdownScout(t, scout).catch(err => TestUtil.shutdownScout(t, scout, err));
+    };
+
+    scout.on(ScoutEvent.RequestSent, listener);
+
+    scout.setup()
+        .then(() => request(app).get("/api/nested/deep/42").expect("Content-Type", /json/).expect(200))
+        .catch(err => TestUtil.shutdownScout(t, scout, err));
+});
+
 // Cleanup the global isntance(s) that get created
 test("Shutdown the global instance", t => {
     const inst = getActiveGlobalScoutInstance();

--- a/test/util.ts
+++ b/test/util.ts
@@ -211,6 +211,31 @@ export function simpleDynamicSegmentExpressApp(middleware: any, delayMs: number 
     return app;
 }
 
+// An express application with routes via express.Router() mounted at /api.
+// Used to verify that scoutMiddleware traces Router-based routes without needing
+// the express integration shim.
+//   GET /api/echo/:name        — one level deep
+//   GET /api/nested/deep/:id   — two levels deep (router inside router)
+export function simpleRouterExpressApp(middleware: any): Application {
+    const app = express();
+    app.use(middleware);
+
+    const router = express.Router();
+    router.get("/echo/:name", (req: Request, res: Response) => {
+        res.json({ status: "success", name: (req.params as any).name });
+    });
+
+    const nested = express.Router();
+    nested.get("/deep/:id", (req: Request, res: Response) => {
+        res.json({ status: "success", id: (req.params as any).id });
+    });
+    router.use("/nested", nested);
+
+    app.use("/api", router);
+
+    return app;
+}
+
 // An express application which errors on the /
 export function simpleErrorApp(middleware: any, delayMs: number = 0): Application {
     const app = express();


### PR DESCRIPTION
## Summary

- Adds `findRoutePathInStack()` — a recursive helper that walks nested `express.Router()` layers to resolve the full route path for transaction naming in `scoutMiddleware`
- Includes the prior Express v5 compatibility fixes (`layer.match()` support and the `commonRouteMiddlewares` cache guard) which were moved here from #330
- Adds two new e2e tests covering one-level and two-level router nesting, exercising the code path directly without the express integration shim

### Problem

Routes mounted via `app.use('/prefix', router)` were invisible to the top-level route scan in `scoutMiddleware`. The middleware only checked `appRouter.stack` layers with `layer.route`, so router-hosted routes fell through to the slower `listExpressEndpoints()` fallback — which could also fail for arbitrary mount paths.

### Fix

Before the `listExpressEndpoints` fallback, the middleware now calls `findRoutePathInStack(appRouter.stack, url, "")`. The function:
1. Checks direct `layer.route` layers (both v4 regexp and v5 `match()`)
2. For `router` layers, confirms the router matches the URL, then strips 1..N leading URL segments to derive the sub-URL and recurses into `layer.handle.stack`
3. Returns the fully-qualified path (e.g. `/birds/raven/feathers`) by accumulating the mount prefix through the recursion

Works with arbitrary nesting depth and both Express 4 and Express 5.

## Test plan

- [ ] `npx tape dist/test/express.e2e.js` — all 37 tests pass including the two new router tests
- [ ] Verify in Scout UI that `/birds/eagle`, `/birds/raven`, `/birds/raven/feathers`, `/birds/raven/calls` all show up with correct transaction names

🤖 Generated with [Claude Code](https://claude.com/claude-code)