### PR TITLE
feat(nest): wire router walk into nestMiddleware for Express v5 / NestJS v11

### DIFF
--- a/dist/lib/express.d.ts
+++ b/dist/lib/express.d.ts
@@ -22,8 +22,8 @@ export declare function listExpressEndpoints(app: any): EndpointInfo[];
 export interface ApplicationWithScout {
     scout?: Scout;
 }
-declare type ExpressMiddleware = (req: any, res: any, next: () => void) => void;
-declare type ExpressErrorMiddleware = (err: any, req: any, res: any, next: (err?: any) => void) => void;
+type ExpressMiddleware = (req: any, res: any, next: () => void) => void;
+type ExpressErrorMiddleware = (err: any, req: any, res: any, next: (err?: any) => void) => void;
 export interface ExpressMiddlewareOptions {
     config?: Partial<ScoutConfiguration>;
     logFn?: LogFn;
@@ -37,7 +37,16 @@ export interface ExpressScoutInfo {
     request?: ScoutRequest;
     rootSpan?: ScoutSpan;
 }
-export declare type ExpressRequestWithScout = Request & ExpressScoutInfo;
+export type ExpressRequestWithScout = Request & ExpressScoutInfo;
+/**
+ * Recursively find the full route path for a URL within a router layer stack.
+ * Handles Express 4 (regexp) and Express 5 (match function) layer formats,
+ * and recurses into nested express.Router() instances.
+ *
+ * Each nested Router's match() operates on the URL relative to its mount point,
+ * so we try stripping 1..N leading segments until a sub-stack match is found.
+ */
+export declare function findRoutePathInStack(stack: any[], url: string, mountPrefix: string): string | null;
 /**
  * Middleware for using scout, this should be
  * attached to the application object using app.use(...)

--- a/dist/lib/express.js
+++ b/dist/lib/express.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.errorMiddleware = exports.scoutMiddleware = exports.findRoutePathInStack = exports.listExpressEndpoints = void 0;
 const onFinished = require("on-finished");
 const async_hooks_1 = require("async_hooks");
 const types_1 = require("./types");
@@ -115,6 +116,59 @@ function parseQueueTimeNS(value) {
 }
 const ROUTE_INFO_LOOKUP = {};
 /**
+ * Recursively find the full route path for a URL within a router layer stack.
+ * Handles Express 4 (regexp) and Express 5 (match function) layer formats,
+ * and recurses into nested express.Router() instances.
+ *
+ * Each nested Router's match() operates on the URL relative to its mount point,
+ * so we try stripping 1..N leading segments until a sub-stack match is found.
+ */
+function findRoutePathInStack(stack, url, mountPrefix) {
+    const segments = url.split("/").filter(Boolean);
+    for (const layer of stack) {
+        if (!layer) {
+            continue;
+        }
+        if (layer.route) {
+            let isMatch = false;
+            if (layer.regexp) {
+                isMatch = layer.regexp.test(url);
+            }
+            else if (typeof layer.match === "function") {
+                isMatch = !!layer.match(url);
+            }
+            if (isMatch) {
+                // Avoid double-slash when a sub-router root ('/') is appended to a non-empty prefix
+                const suffix = layer.route.path === "/" && mountPrefix !== "" ? "" : layer.route.path;
+                return mountPrefix + suffix;
+            }
+        }
+        else if (layer.name === "router" && layer.handle && layer.handle.stack) {
+            let routerMatches = false;
+            if (layer.regexp) {
+                routerMatches = layer.regexp.test(url);
+            }
+            else if (typeof layer.match === "function") {
+                routerMatches = !!layer.match(url);
+            }
+            if (!routerMatches) {
+                continue;
+            }
+            // Strip 1..N leading segments to derive the sub-URL relative to the nested router
+            for (let i = 1; i <= segments.length; i++) {
+                const nestedMount = mountPrefix + "/" + segments.slice(0, i).join("/");
+                const nestedUrl = segments.slice(i).length > 0 ? "/" + segments.slice(i).join("/") : "/";
+                const result = findRoutePathInStack(layer.handle.stack, nestedUrl, nestedMount);
+                if (result) {
+                    return result;
+                }
+            }
+        }
+    }
+    return null;
+}
+exports.findRoutePathInStack = findRoutePathInStack;
+/**
  * Middleware for using scout, this should be
  * attached to the application object using app.use(...)
  *
@@ -127,23 +181,23 @@ function scoutMiddleware(opts) {
     const commonRouteMiddlewares = [];
     // Build configuration overrides
     const overrides = opts && opts.config ? opts.config : {};
-    const config = types_1.buildScoutConfiguration(overrides);
+    const config = (0, types_1.buildScoutConfiguration)(overrides);
     const options = {
         logFn: opts && opts.logFn ? opts.logFn : undefined,
         statisticsIntervalMS: opts && opts.statisticsIntervalMS ? opts.statisticsIntervalMS : undefined,
     };
     // Set the last used configurations
-    global_1.setGlobalLastUsedConfiguration(config);
-    global_1.setGlobalLastUsedOptions(options);
+    (0, global_1.setGlobalLastUsedConfiguration)(config);
+    (0, global_1.setGlobalLastUsedOptions)(options);
     return (req, res, next) => {
         const requestStartTimeNS = getNanoTime();
         // If there is no global scout instance yet and no scout instance just go to next middleware immediately
-        const scout = opts && opts.scout ? opts.scout : req.app.scout || global_1.getActiveGlobalScoutInstance();
+        const scout = opts && opts.scout ? opts.scout : req.app.scout || (0, global_1.getActiveGlobalScoutInstance)();
         // Build a closure that installs scout (and waits on it)
         // depending on whether waitForScoutSetup is set we will run this in the background or inline
         const setupScout = () => {
             // If app doesn't already have a scout instance *and* no active global one is present, create one
-            return global_1.getOrCreateActiveGlobalScoutInstance(config, options)
+            return (0, global_1.getOrCreateActiveGlobalScoutInstance)(config, options)
                 .then(scout => req.app.scout = scout);
         };
         const waitForScoutSetup = opts && opts.waitForScoutSetup;
@@ -169,7 +223,15 @@ function scoutMiddleware(opts) {
         // The query of the URL needs to be  stripped before attempting to test it against express regexps
         // i.e. all route regexps end in /..\?$/
         const preQueryUrl = reqUrl.split("?")[0];
-        let matchedRouteMiddleware = commonRouteMiddlewares.find((m) => m.regexp.test(preQueryUrl));
+        let matchedRouteMiddleware = commonRouteMiddlewares.find((m) => {
+            if (m.regexp) {
+                return m.regexp.test(preQueryUrl);
+            }
+            if (typeof m.match === "function") {
+                return m.match(preQueryUrl);
+            }
+            return false;
+        });
         // If we couldn't find a route in the ones that have worked before,
         // then we have to search the router stack
         // Express 4 uses _router; Express 5 uses router (a getter that throws on Express 4)
@@ -184,12 +246,18 @@ function scoutMiddleware(opts) {
             // Find routes that match the current URL
             matchedRouteMiddleware = appRouter.stack
                 .filter((middleware) => {
-                // We can recognize a middleware as a route if .route & .regexp are present
-                if (!middleware || !middleware.route || !middleware.regexp) {
+                if (!middleware || !middleware.route) {
                     return false;
                 }
-                // Check if the URL matches the route
-                const isMatch = middleware.regexp.test(preQueryUrl);
+                // Express v4: layer has a pre-built regexp
+                // Express v5: layer has a match() method instead
+                let isMatch = false;
+                if (middleware.regexp) {
+                    isMatch = middleware.regexp.test(preQueryUrl);
+                }
+                else if (typeof middleware.match === "function") {
+                    isMatch = middleware.match(preQueryUrl);
+                }
                 // Add matches in the hope that common routes will be faster than searching everything
                 if (isMatch) {
                     commonRouteMiddlewares.push(middleware);
@@ -201,6 +269,15 @@ function scoutMiddleware(opts) {
         // (for the request name, e.x. "Controller/GET <some path>")
         if (matchedRouteMiddleware) {
             routePath = matchedRouteMiddleware.route.path;
+        }
+        // If still no match, walk nested express.Router() stacks recursively.
+        // This handles routes mounted via app.use('/prefix', router) that are invisible
+        // to the top-level stack scan (which only looks at layers with layer.route).
+        if (!routePath && appRouter && appRouter.stack) {
+            const nestedPath = findRoutePathInStack(appRouter.stack, preQueryUrl, "");
+            if (nestedPath) {
+                routePath = nestedPath;
+            }
         }
         // If we get to this point and matchedRouteMiddleware is still empty/missing
         // we're likely in the case of a nested express.Router and cannot rely on
@@ -218,7 +295,7 @@ function scoutMiddleware(opts) {
                     listExpressEndpoints(req.app)
                         .forEach(r => {
                         // Enrich endpoint list with regexes for the full match
-                        r.regex = path_to_regexp_1.pathToRegexp(r.path);
+                        r.regex = (0, path_to_regexp_1.pathToRegexp)(r.path);
                         ROUTE_INFO_LOOKUP[r.path] = Object.assign(Object.assign({}, r), { middleware: r.middleware || [], regex: r.regex });
                     });
                     // Search again after adding to the cache

--- a/dist/lib/nest.d.ts
+++ b/dist/lib/nest.d.ts
@@ -8,7 +8,7 @@ export interface NestMiddlewareOptions {
     scout?: Scout;
     waitForScoutSetup?: boolean;
 }
-declare type NestMiddleware = (req: any, res: any, next: () => void) => void;
+type NestMiddleware = (req: any, res: any, next: () => void) => void;
 export declare function nestMiddleware(opts?: NestMiddlewareOptions): NestMiddleware;
 /**
  * Class-based Scout middleware for use with NestJS's MiddlewareConsumer.

--- a/dist/lib/nest.js
+++ b/dist/lib/nest.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.nestErrorFilter = exports.ScoutNestMiddleware = exports.nestMiddleware = void 0;
 const onFinished = require("on-finished");
 const async_hooks_1 = require("async_hooks");
 const types_1 = require("./types");
@@ -29,17 +30,17 @@ function parseQueueTimeNS(value) {
 }
 function nestMiddleware(opts) {
     const overrides = opts && opts.config ? opts.config : {};
-    const config = types_1.buildScoutConfiguration(overrides);
+    const config = (0, types_1.buildScoutConfiguration)(overrides);
     const options = {
         logFn: opts && opts.logFn ? opts.logFn : undefined,
         statisticsIntervalMS: opts && opts.statisticsIntervalMS ? opts.statisticsIntervalMS : undefined,
     };
-    global_1.setGlobalLastUsedConfiguration(config);
-    global_1.setGlobalLastUsedOptions(options);
+    (0, global_1.setGlobalLastUsedConfiguration)(config);
+    (0, global_1.setGlobalLastUsedOptions)(options);
     return (req, res, next) => {
         const requestStartTimeNS = getNanoTime();
-        const scout = opts && opts.scout ? opts.scout : req.app.scout || global_1.getActiveGlobalScoutInstance();
-        const setupScout = () => global_1.getOrCreateActiveGlobalScoutInstance(config, options)
+        const scout = opts && opts.scout ? opts.scout : req.app.scout || (0, global_1.getActiveGlobalScoutInstance)();
+        const setupScout = () => (0, global_1.getOrCreateActiveGlobalScoutInstance)(config, options)
             .then(s => req.app.scout = s);
         const waitForScoutSetup = opts && opts.waitForScoutSetup;
         if (!scout && !waitForScoutSetup) {
@@ -56,16 +57,28 @@ function nestMiddleware(opts) {
         }
         const reqUrl = req.url;
         const preQueryUrl = reqUrl.split("?")[0];
-        // NestJS routes are always registered on a nested Express Router, never as
-        // top-level layers on app._router.  Skip the flat stack scan and go straight
-        // to listExpressEndpoints which walks the full nested tree.
+        // NestJS routes are registered on nested Express Routers.  Try walking the
+        // router stack directly first (handles Express v5 where listExpressEndpoints
+        // probing is limited), then fall back to listExpressEndpoints.
         let routePath = reqUrl === "/" ? "/" : null;
+        if (!routePath) {
+            try {
+                const appRouter = req.app._router || (req.app.router && req.app.router());
+                if (appRouter && appRouter.stack) {
+                    const walked = (0, express_1.findRoutePathInStack)(appRouter.stack, preQueryUrl, "");
+                    if (walked) {
+                        routePath = walked;
+                    }
+                }
+            }
+            catch (_e) { /* ignore */ }
+        }
         if (!routePath) {
             try {
                 let matchedRoute = Object.values(NEST_ROUTE_INFO_LOOKUP).find(r => r.regex.exec(preQueryUrl));
                 if (!matchedRoute) {
-                    express_1.listExpressEndpoints(req.app).forEach(r => {
-                        NEST_ROUTE_INFO_LOOKUP[r.path] = Object.assign(Object.assign({}, r), { regex: path_to_regexp_1.pathToRegexp(r.path) });
+                    (0, express_1.listExpressEndpoints)(req.app).forEach(r => {
+                        NEST_ROUTE_INFO_LOOKUP[r.path] = Object.assign(Object.assign({}, r), { regex: (0, path_to_regexp_1.pathToRegexp)(r.path) });
                     });
                     matchedRoute = Object.values(NEST_ROUTE_INFO_LOOKUP).find(r => r.regex.exec(preQueryUrl));
                 }

--- a/dist/test/integration/nest.int.js
+++ b/dist/test/integration/nest.int.js
@@ -44,14 +44,60 @@ tslib_1.__decorate([
 ApiController = tslib_1.__decorate([
     (0, common_1.Controller)("api")
 ], ApiController);
+let ProductsController = class ProductsController {
+    list() { return { route: "GET /products" }; }
+    featured() { return { route: "GET /products/featured" }; }
+    getById(id) { return { route: "GET /products/:id", id }; }
+};
+tslib_1.__decorate([
+    (0, common_1.Get)(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ProductsController.prototype, "list", null);
+tslib_1.__decorate([
+    (0, common_1.Get)("featured"),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ProductsController.prototype, "featured", null);
+tslib_1.__decorate([
+    (0, common_1.Get)(":id"),
+    tslib_1.__param(0, (0, common_1.Param)("id")),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", [String]),
+    tslib_1.__metadata("design:returntype", void 0)
+], ProductsController.prototype, "getById", null);
+ProductsController = tslib_1.__decorate([
+    (0, common_1.Controller)("products")
+], ProductsController);
+let OrdersController = class OrdersController {
+    tracking(orderId, trackingId) { return { orderId, trackingId }; }
+};
+tslib_1.__decorate([
+    (0, common_1.Get)(":orderId/tracking/:trackingId"),
+    tslib_1.__param(0, (0, common_1.Param)("orderId")),
+    tslib_1.__param(1, (0, common_1.Param)("trackingId")),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", [String, String]),
+    tslib_1.__metadata("design:returntype", void 0)
+], OrdersController.prototype, "tracking", null);
+OrdersController = tslib_1.__decorate([
+    (0, common_1.Controller)("orders")
+], OrdersController);
 let TestModule = class TestModule {
 };
 TestModule = tslib_1.__decorate([
     (0, common_1.Module)({ controllers: [TestController, ApiController] })
 ], TestModule);
+let ExtendedTestModule = class ExtendedTestModule {
+};
+ExtendedTestModule = tslib_1.__decorate([
+    (0, common_1.Module)({ controllers: [TestController, ApiController, ProductsController, OrdersController] })
+], ExtendedTestModule);
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function buildConfig(mock, extra) {
-    return (0, types_1.buildScoutConfiguration)(Object.assign({ monitor: true, coreAgentDownload: false, coreAgentLaunch: false, socketPath: mock.socketPath() }, extra));
+    return (0, types_1.buildScoutConfiguration)(Object.assign({ allowShutdown: true, monitor: true, coreAgentDownload: false, coreAgentLaunch: false, socketPath: mock.socketPath() }, extra));
 }
 function nextRequestSent(scout) {
     return new Promise((resolve, reject) => {
@@ -73,6 +119,14 @@ function nextRequestSent(scout) {
 function makeNestApp(scout) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
         const app = yield core_1.NestFactory.create(TestModule, { logger: false });
+        app.use((0, nest_1.nestMiddleware)({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+        yield app.init();
+        return app;
+    });
+}
+function makeExtendedNestApp(scout) {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () {
+        const app = yield core_1.NestFactory.create(ExtendedTestModule, { logger: false });
         app.use((0, nest_1.nestMiddleware)({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
         yield app.init();
         return app;
@@ -163,6 +217,70 @@ test("NestJS controller prefix is included in span operation", { timeout: TIMEOU
         const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
         t.ok(ctrl, "Controller span created for prefixed route");
         t.equal(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation, "Controller/GET /api/hello", "full path with prefix captured");
+    })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+        mock.stop().catch(() => undefined);
+        nestApp === null || nestApp === void 0 ? void 0 : nestApp.close().catch(() => undefined);
+        t.fail(err.message);
+        t.end();
+    });
+});
+test("NestJS controller with arbitrary prefix resolves via router walk", { timeout: TIMEOUT }, (t) => {
+    const mock = new mock_agent_1.MockAgent();
+    let nestApp;
+    let scout;
+    mock.start()
+        .then(() => tslib_1.__awaiter(void 0, void 0, void 0, function* () {
+        scout = new scout_1.Scout(buildConfig(mock));
+        yield scout.setup();
+        nestApp = yield makeExtendedNestApp(scout);
+    }))
+        .then(() => {
+        const sentPromise = nextRequestSent(scout);
+        request(nestApp.getHttpServer()).get("/products/featured").end(() => undefined);
+        return sentPromise;
+    })
+        .then((data) => {
+        const spans = data.request.getChildSpansSync();
+        const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+        t.ok(ctrl, "Controller span created for /products/featured");
+        t.equal(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation, "Controller/GET /products/featured", "correct static sub-route under arbitrary prefix");
+    })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+        mock.stop().catch(() => undefined);
+        nestApp === null || nestApp === void 0 ? void 0 : nestApp.close().catch(() => undefined);
+        t.fail(err.message);
+        t.end();
+    });
+});
+test("NestJS parameterized route under arbitrary prefix resolves via router walk", { timeout: TIMEOUT }, (t) => {
+    const mock = new mock_agent_1.MockAgent();
+    let nestApp;
+    let scout;
+    mock.start()
+        .then(() => tslib_1.__awaiter(void 0, void 0, void 0, function* () {
+        scout = new scout_1.Scout(buildConfig(mock));
+        yield scout.setup();
+        nestApp = yield makeExtendedNestApp(scout);
+    }))
+        .then(() => {
+        const sentPromise = nextRequestSent(scout);
+        request(nestApp.getHttpServer()).get("/orders/42/tracking/TRK-999").end(() => undefined);
+        return sentPromise;
+    })
+        .then((data) => {
+        const spans = data.request.getChildSpansSync();
+        const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+        t.ok(ctrl, "Controller span created for multi-param route");
+        t.equal(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation, "Controller/GET /orders/:orderId/tracking/:trackingId", "multi-param pattern captured");
+        t.notOk(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation.includes("42"), "concrete orderId not in operation");
+        t.notOk(ctrl === null || ctrl === void 0 ? void 0 : ctrl.operation.includes("TRK-999"), "concrete trackingId not in operation");
     })
         .then(() => nestApp.close())
         .then(() => TestUtil.shutdownScout(t, scout))

--- a/lib/express.ts
+++ b/lib/express.ts
@@ -184,6 +184,44 @@ interface EndpointListingItem {
 const ROUTE_INFO_LOOKUP: {[key: string]: EndpointListingItem} = {};
 
 /**
+ * Recursively find the full route path for a URL within a router layer stack.
+ * Handles Express 4 (regexp) and Express 5 (match function) layer formats,
+ * and recurses into nested express.Router() instances.
+ *
+ * Each nested Router's match() operates on the URL relative to its mount point,
+ * so we try stripping 1..N leading segments until a sub-stack match is found.
+ */
+export function findRoutePathInStack(stack: any[], url: string, mountPrefix: string): string | null {
+    const segments = url.split("/").filter(Boolean);
+    for (const layer of stack) {
+        if (!layer) { continue; }
+        if (layer.route) {
+            let isMatch = false;
+            if (layer.regexp) { isMatch = layer.regexp.test(url); }
+            else if (typeof layer.match === "function") { isMatch = !!layer.match(url); }
+            if (isMatch) {
+                // Avoid double-slash when a sub-router root ('/') is appended to a non-empty prefix
+                const suffix = layer.route.path === "/" && mountPrefix !== "" ? "" : layer.route.path;
+                return mountPrefix + suffix;
+            }
+        } else if (layer.name === "router" && layer.handle && layer.handle.stack) {
+            let routerMatches = false;
+            if (layer.regexp) { routerMatches = layer.regexp.test(url); }
+            else if (typeof layer.match === "function") { routerMatches = !!layer.match(url); }
+            if (!routerMatches) { continue; }
+            // Strip 1..N leading segments to derive the sub-URL relative to the nested router
+            for (let i = 1; i <= segments.length; i++) {
+                const nestedMount = mountPrefix + "/" + segments.slice(0, i).join("/");
+                const nestedUrl = segments.slice(i).length > 0 ? "/" + segments.slice(i).join("/") : "/";
+                const result = findRoutePathInStack(layer.handle.stack, nestedUrl, nestedMount);
+                if (result) { return result; }
+            }
+        }
+    }
+    return null;
+}
+
+/**
  * Middleware for using scout, this should be
  * attached to the application object using app.use(...)
  *
@@ -248,7 +286,11 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
         // The query of the URL needs to be  stripped before attempting to test it against express regexps
         // i.e. all route regexps end in /..\?$/
         const preQueryUrl = reqUrl.split("?")[0];
-        let matchedRouteMiddleware = commonRouteMiddlewares.find((m: any) => m.regexp.test(preQueryUrl));
+        let matchedRouteMiddleware = commonRouteMiddlewares.find((m: any) => {
+            if (m.regexp) { return m.regexp.test(preQueryUrl); }
+            if (typeof m.match === "function") { return m.match(preQueryUrl); }
+            return false;
+        });
 
         // If we couldn't find a route in the ones that have worked before,
         // then we have to search the router stack
@@ -261,11 +303,16 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
             // Find routes that match the current URL
             matchedRouteMiddleware = appRouter.stack
                 .filter((middleware: any) => {
-                    // We can recognize a middleware as a route if .route & .regexp are present
-                    if (!middleware || !middleware.route || !middleware.regexp) { return false; }
+                    if (!middleware || !middleware.route) { return false; }
 
-                    // Check if the URL matches the route
-                    const isMatch = middleware.regexp.test(preQueryUrl);
+                    // Express v4: layer has a pre-built regexp
+                    // Express v5: layer has a match() method instead
+                    let isMatch = false;
+                    if (middleware.regexp) {
+                        isMatch = middleware.regexp.test(preQueryUrl);
+                    } else if (typeof middleware.match === "function") {
+                        isMatch = middleware.match(preQueryUrl);
+                    }
 
                     // Add matches in the hope that common routes will be faster than searching everything
                     if (isMatch) { commonRouteMiddlewares.push(middleware); }
@@ -278,6 +325,14 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
         // (for the request name, e.x. "Controller/GET <some path>")
         if (matchedRouteMiddleware) {
             routePath = matchedRouteMiddleware.route.path;
+        }
+
+        // If still no match, walk nested express.Router() stacks recursively.
+        // This handles routes mounted via app.use('/prefix', router) that are invisible
+        // to the top-level stack scan (which only looks at layers with layer.route).
+        if (!routePath && appRouter && appRouter.stack) {
+            const nestedPath = findRoutePathInStack(appRouter.stack, preQueryUrl, "");
+            if (nestedPath) { routePath = nestedPath; }
         }
 
         // If we get to this point and matchedRouteMiddleware is still empty/missing
@@ -336,7 +391,7 @@ export function scoutMiddleware(opts?: ExpressMiddlewareOptions): ExpressMiddlew
             .then(scout => req.app.scout = scout)
         // Set up the scout instance (if necessary)
             .then(scout => scout.setup())
-        // Start performing middleware duties
+        // Start perofrming midleware duties
             .then(scout => {
                 // If we get here but have no route path,
                 // (meaning we couldn't figure it out from a matched middleware or full route listing)

--- a/lib/nest.ts
+++ b/lib/nest.ts
@@ -16,7 +16,7 @@ import {
     setGlobalLastUsedConfiguration,
     setGlobalLastUsedOptions,
 } from "./global";
-import { listExpressEndpoints, EndpointInfo, ApplicationWithScout, ExpressScoutInfo } from "./express";
+import { listExpressEndpoints, findRoutePathInStack, EndpointInfo, ApplicationWithScout, ExpressScoutInfo } from "./express";
 import { pathToRegexp } from "path-to-regexp";
 
 const getNanoTime = require("nano-time");
@@ -87,10 +87,20 @@ export function nestMiddleware(opts?: NestMiddlewareOptions): NestMiddleware {
         const reqUrl = req.url;
         const preQueryUrl = reqUrl.split("?")[0];
 
-        // NestJS routes are always registered on a nested Express Router, never as
-        // top-level layers on app._router.  Skip the flat stack scan and go straight
-        // to listExpressEndpoints which walks the full nested tree.
+        // NestJS routes are registered on nested Express Routers.  Try walking the
+        // router stack directly first (handles Express v5 where listExpressEndpoints
+        // probing is limited), then fall back to listExpressEndpoints.
         let routePath: string | null = reqUrl === "/" ? "/" : null;
+
+        if (!routePath) {
+            try {
+                const appRouter = req.app._router || (req.app.router && req.app.router());
+                if (appRouter && appRouter.stack) {
+                    const walked = findRoutePathInStack(appRouter.stack, preQueryUrl, "");
+                    if (walked) { routePath = walked; }
+                }
+            } catch (_e) { /* ignore */ }
+        }
 
         if (!routePath) {
             try {

--- a/test/integration/nest.int.ts
+++ b/test/integration/nest.int.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import * as test from "tape";
 import * as request from "supertest";
 import { NestFactory } from "@nestjs/core";
-import { Module, Controller, Get } from "@nestjs/common";
+import { Module, Controller, Get, Param } from "@nestjs/common";
 import { MockAgent } from "./mock-agent";
 import { nestMiddleware } from "../../lib/nest";
 import { Scout } from "../../lib/scout";
@@ -29,13 +29,38 @@ class ApiController {
     public hello() { return { message: "hello" }; }
 }
 
+@Controller("products")
+class ProductsController {
+    @Get()
+    list() { return { route: "GET /products" }; }
+
+    @Get("featured")
+    featured() { return { route: "GET /products/featured" }; }
+
+    @Get(":id")
+    getById(@Param("id") id: string) { return { route: "GET /products/:id", id }; }
+}
+
+@Controller("orders")
+class OrdersController {
+    @Get(":orderId/tracking/:trackingId")
+    tracking(
+        @Param("orderId") orderId: string,
+        @Param("trackingId") trackingId: string,
+    ) { return { orderId, trackingId }; }
+}
+
 @Module({ controllers: [TestController, ApiController] })
 class TestModule {}
+
+@Module({ controllers: [TestController, ApiController, ProductsController, OrdersController] })
+class ExtendedTestModule {}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function buildConfig(mock: MockAgent, extra?: object) {
     return buildScoutConfiguration({
+        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,
@@ -66,6 +91,13 @@ function nextRequestSent(scout: Scout): Promise<ScoutEventRequestSentData> {
 
 async function makeNestApp(scout: Scout): Promise<any> {
     const app = await NestFactory.create(TestModule, { logger: false });
+    app.use(nestMiddleware({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
+    await app.init();
+    return app;
+}
+
+async function makeExtendedNestApp(scout: Scout): Promise<any> {
+    const app = await NestFactory.create(ExtendedTestModule, { logger: false });
     app.use(nestMiddleware({ scout, requestTimeoutMs: 0, waitForScoutSetup: true }));
     await app.init();
     return app;
@@ -168,6 +200,78 @@ test("NestJS controller prefix is included in span operation", { timeout: TIMEOU
             const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
             t.ok(ctrl, "Controller span created for prefixed route");
             t.equal(ctrl?.operation, "Controller/GET /api/hello", "full path with prefix captured");
+        })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+            mock.stop().catch(() => undefined);
+            nestApp?.close().catch(() => undefined);
+            t.fail(err.message);
+            t.end();
+        });
+});
+
+test("NestJS controller with arbitrary prefix resolves via router walk", { timeout: TIMEOUT }, (t) => {
+    const mock = new MockAgent();
+    let nestApp: any;
+    let scout: Scout;
+
+    mock.start()
+        .then(async () => {
+            scout = new Scout(buildConfig(mock));
+            await scout.setup();
+            nestApp = await makeExtendedNestApp(scout);
+        })
+        .then(() => {
+            const sentPromise = nextRequestSent(scout);
+            request(nestApp.getHttpServer()).get("/products/featured").end(() => undefined);
+            return sentPromise;
+        })
+        .then((data) => {
+            const spans = data.request.getChildSpansSync();
+            const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+            t.ok(ctrl, "Controller span created for /products/featured");
+            t.equal(ctrl?.operation, "Controller/GET /products/featured", "correct static sub-route under arbitrary prefix");
+        })
+        .then(() => nestApp.close())
+        .then(() => TestUtil.shutdownScout(t, scout))
+        .then(() => mock.stop())
+        .catch((err) => {
+            mock.stop().catch(() => undefined);
+            nestApp?.close().catch(() => undefined);
+            t.fail(err.message);
+            t.end();
+        });
+});
+
+test("NestJS parameterized route under arbitrary prefix resolves via router walk", { timeout: TIMEOUT }, (t) => {
+    const mock = new MockAgent();
+    let nestApp: any;
+    let scout: Scout;
+
+    mock.start()
+        .then(async () => {
+            scout = new Scout(buildConfig(mock));
+            await scout.setup();
+            nestApp = await makeExtendedNestApp(scout);
+        })
+        .then(() => {
+            const sentPromise = nextRequestSent(scout);
+            request(nestApp.getHttpServer()).get("/orders/42/tracking/TRK-999").end(() => undefined);
+            return sentPromise;
+        })
+        .then((data) => {
+            const spans = data.request.getChildSpansSync();
+            const ctrl = spans.find((s) => s.operation.startsWith("Controller/"));
+            t.ok(ctrl, "Controller span created for multi-param route");
+            t.equal(
+                ctrl?.operation,
+                "Controller/GET /orders/:orderId/tracking/:trackingId",
+                "multi-param pattern captured",
+            );
+            t.notOk(ctrl?.operation.includes("42"), "concrete orderId not in operation");
+            t.notOk(ctrl?.operation.includes("TRK-999"), "concrete trackingId not in operation");
         })
         .then(() => nestApp.close())
         .then(() => TestUtil.shutdownScout(t, scout))


### PR DESCRIPTION
## Summary

- **Exports** `findRoutePathInStack` from `lib/express.ts` so it can be reused by other middleware
- **Wires** `findRoutePathInStack` into `nestMiddleware` as the first route-resolution step, before the `listExpressEndpoints` fallback
- **Adds 2 integration tests** verifying arbitrary-prefix NestJS controllers are resolved correctly via the router walk

## Problem

NestJS v11 defaults to Express v5 as its HTTP adapter. Express v5 router layers expose a `match()` function instead of a `.regexp`. The previous `nestMiddleware` relied solely on `listExpressEndpoints`, which probes a fixed set of paths (`/`, `/api`, `/v1`, `/v2`, `/admin`, `/auth`) and misses arbitrary controller prefixes like `/products`, `/orders`, `/customers`.

## Solution

`findRoutePathInStack` (added in the companion `feature/express-router-walk` PR) already handles both Express v4 (regexp) and Express v5 (match function) layer styles. Wiring it into `nestMiddleware` before `listExpressEndpoints` means all controller prefixes are found via direct stack walk, with `listExpressEndpoints` as a safety fallback.

## Test results

New integration tests added to `test/integration/nest.int.ts`:
- **Arbitrary-prefix static sub-route**: `GET /products/featured` → `Controller/GET /products/featured` ✓
- **Multi-param route**: `GET /orders/:orderId/tracking/:trackingId` with concrete values → pattern correctly captured ✓

31/31 integration tests pass.

Verified manually against the `nest-prisma` test app (NestJS + Prisma + Express v5) with 32 endpoints across 6 controllers — all routes resolved to correct parameterized patterns.

## Test plan

- [x] `npm run test-int` — 31/31 pass
- [x] All 32 nest-prisma endpoints hit and verified via diagnostics
- [x] Parameterized routes (`/:id`, `/:orderId/tracking/:trackingId`, `/:year/:month`) capture patterns not concrete values

🤖 Generated with [Claude Code](https://claude.com/claude-code)