### PR TITLE
chore: add npm publish workflow and RELEASING guide

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+      - run: yarn install
+      - run: yarn generate
+      - run: yarn build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,38 @@
+# Releasing
+
+## Prerequisites
+
+The `NPM_TOKEN` secret must be set in the GitHub repository (Settings → Secrets → Actions).
+Generate one at npmjs.com → Account → Access Tokens → New Token → **Automation** type.
+
+## Steps
+
+1. **Merge all changes to master** — the release commit should be on master.
+
+2. **Bump the version in `package.json`**:
+   ```sh
+   # Edit package.json "version" field, e.g. "0.2.3" → "0.2.4"
+   # Then commit:
+   git add package.json
+   git commit -m "chore: bump version to 0.2.4"
+   git push origin master
+   ```
+
+3. **Tag the commit and push the tag**:
+   ```sh
+   git tag v0.2.4
+   git push origin v0.2.4
+   ```
+
+4. **The publish workflow fires automatically** on tag push. It runs `yarn build` then
+   `npm publish`, which puts `@scout_apm/scout-apm@0.2.4` on the npm registry
+   (Yarn pulls from the same registry).
+
+5. **Verify** at https://www.npmjs.com/package/@scout_apm/scout-apm
+
+## Notes
+
+- The tag must match `v*` (e.g. `v0.2.4`, `v1.0.0`).
+- The version in `package.json` must match the tag (minus the `v` prefix) — npm uses
+  the `package.json` version, not the tag name.
+- To do a dry run locally: `npm publish --dry-run`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,16 +9,17 @@ Generate one at npmjs.com → Account → Access Tokens → New Token → **Auto
 
 1. **Merge all changes to master** — the release commit should be on master.
 
-2. **Bump the version in `package.json`**:
+2. **Bump the version in `package.json`** via a PR — do not push directly to master:
    ```sh
+   git checkout -b chore/bump-version-0.2.4
    # Edit package.json "version" field, e.g. "0.2.3" → "0.2.4"
-   # Then commit:
    git add package.json
    git commit -m "chore: bump version to 0.2.4"
-   git push origin master
+   git push origin chore/bump-version-0.2.4
+   # Open a PR, get approval, then merge to master
    ```
 
-3. **Tag the commit and push the tag**:
+3. **Tag the merged master commit and push the tag**:
    ```sh
    git tag v0.2.4
    git push origin v0.2.4


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` — triggers on any `v*` tag push, runs `yarn build` then `npm publish`
- Adds `RELEASING.md` — documents the release process step by step

## Required setup

Add `NPM_TOKEN` as a GitHub Actions secret (Settings → Secrets → Actions). Generate at npmjs.com → Account → Access Tokens → New Token → **Automation** type.

## Release process

```sh
# 1. Bump version in package.json, commit, merge to master
# 2. Tag and push:
git tag v0.2.4
git push origin v0.2.4
```

The workflow fires automatically and publishes to npm (Yarn pulls from the same registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)