### PR TITLE
feat: add trackJobQueueTime helper and job queue context names

### DIFF
--- a/dist/lib/index.d.ts
+++ b/dist/lib/index.d.ts
@@ -2,6 +2,7 @@ import * as Errors from "./errors";
 import { scoutMiddleware as expressMiddleware, errorMiddleware } from "./express";
 import { nestMiddleware as nestMiddlewareImpl, nestErrorFilter as nestErrorFilterImpl } from "./nest";
 import { captureError } from "./error-monitor";
+import { trackJobQueueTime } from "./job-queue-time";
 import { Scout, ScoutRequest, DoneCallback, SpanCallback, RequestCallback } from "./scout";
 import { ScoutConfiguration, JSONValue, buildScoutConfiguration, consoleLogFn, buildWinstonLogFn } from "./types";
 import { getOrCreateActiveGlobalScoutInstance } from "./global";
@@ -15,30 +16,31 @@ declare const API: {
     nestMiddleware: typeof nestMiddlewareImpl;
     nestErrorFilter: typeof nestErrorFilterImpl;
     captureError: typeof captureError;
+    trackJobQueueTime: typeof trackJobQueueTime;
     consoleLogFn: typeof consoleLogFn;
     buildWinstonLogFn: typeof buildWinstonLogFn;
     install: typeof getOrCreateActiveGlobalScoutInstance;
     init(config: Partial<ScoutConfiguration>): Promise<Scout>;
-    instrument(op: string, cb: DoneCallback, scout?: Scout | undefined): Promise<any>;
-    instrumentSync(op: string, cb: SpanCallback, scout?: Scout | undefined): Promise<any>;
+    instrument(op: string, cb: DoneCallback, scout?: Scout): Promise<any>;
+    instrumentSync(op: string, cb: SpanCallback, scout?: Scout): Promise<any>;
     api: {
         WebTransaction: {
-            run(op: string, cb: DoneCallback, scout?: Scout | undefined): Promise<any>;
-            runSync(op: string, cb: RequestCallback, scout?: Scout | undefined): any;
+            run(op: string, cb: DoneCallback, scout?: Scout): Promise<any>;
+            runSync(op: string, cb: RequestCallback, scout?: Scout): any;
         };
         BackgroundTransaction: {
-            run(op: string, cb: DoneCallback, scout?: Scout | undefined): Promise<any>;
-            runSync(op: string, cb: SpanCallback, scout?: Scout | undefined): any;
+            run(op: string, cb: DoneCallback, scout?: Scout): Promise<any>;
+            runSync(op: string, cb: SpanCallback, scout?: Scout): any;
         };
-        instrument(op: string, cb: DoneCallback, scout?: Scout | undefined): Promise<any>;
-        instrumentSync(operation: string, fn: SpanCallback, scout?: Scout | undefined): Promise<any>;
+        instrument(op: string, cb: DoneCallback, scout?: Scout): Promise<any>;
+        instrumentSync(operation: string, fn: SpanCallback, scout?: Scout): Promise<any>;
         readonly Config: Partial<ScoutConfiguration> | undefined;
         Context: {
-            add(name: string, value: JSONValue, scout?: Scout | undefined): Promise<void | ScoutRequest>;
-            addSync(name: string, value: JSONValue, scout?: Scout | undefined): ScoutRequest | undefined;
+            add(name: string, value: JSONValue, scout?: Scout): Promise<ScoutRequest | void>;
+            addSync(name: string, value: JSONValue, scout?: Scout): ScoutRequest | undefined;
         };
-        ignoreTransaction(scout?: Scout | undefined): Promise<void | ScoutRequest>;
-        ignoreTransactionSync(scout?: Scout | undefined): void | ScoutRequest;
+        ignoreTransaction(scout?: Scout): Promise<ScoutRequest | void>;
+        ignoreTransactionSync(scout?: Scout): ScoutRequest | void;
     };
 };
 export = API;

--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -3,6 +3,7 @@ const Errors = require("./errors");
 const express_1 = require("./express");
 const nest_1 = require("./nest");
 const error_monitor_1 = require("./error-monitor");
+const job_queue_time_1 = require("./job-queue-time");
 const types_1 = require("./types");
 const integrations_1 = require("./integrations");
 const global_1 = require("./global");
@@ -11,9 +12,9 @@ const global_1 = require("./global");
 // Hooks are no-ops until the package is actually required — safe to call for
 // packages that aren't installed.
 function setupRequireIntegrations(packages) {
-    const list = (packages !== null && packages !== void 0 ? packages : integrations_1.KNOWN_PACKAGES);
+    const list = packages !== null && packages !== void 0 ? packages : integrations_1.KNOWN_PACKAGES;
     list.forEach(name => {
-        const integration = integrations_1.getIntegrationForPackage(name);
+        const integration = (0, integrations_1.getIntegrationForPackage)(name);
         if (integration) {
             integration.ritmHook(global_1.EXPORT_BAG);
         }
@@ -35,6 +36,8 @@ const API = {
     nestErrorFilter: nest_1.nestErrorFilter,
     // Error monitoring
     captureError: error_monitor_1.captureError,
+    // Background jobs
+    trackJobQueueTime: job_queue_time_1.trackJobQueueTime,
     // Logging
     consoleLogFn: types_1.consoleLogFn,
     buildWinstonLogFn: types_1.buildWinstonLogFn,
@@ -46,11 +49,11 @@ const API = {
     // Use this instead of a separate setupRequireIntegrations() + install() pair.
     init(config) {
         setupRequireIntegrations();
-        return global_1.getOrCreateActiveGlobalScoutInstance(config);
+        return (0, global_1.getOrCreateActiveGlobalScoutInstance)(config);
     },
     // instrument
     instrument(op, cb, scout) {
-        return (scout ? Promise.resolve(scout.setup()) : global_1.getOrCreateActiveGlobalScoutInstance())
+        return (scout ? Promise.resolve(scout.setup()) : (0, global_1.getOrCreateActiveGlobalScoutInstance)())
             .then(scout => {
             return scout.instrument(op, (finishSpan, info) => {
                 return cb(finishSpan, info);
@@ -59,7 +62,7 @@ const API = {
     },
     // instrument
     instrumentSync(op, cb, scout) {
-        return (scout ? Promise.resolve(scout.setup()) : global_1.getOrCreateActiveGlobalScoutInstance())
+        return (scout ? Promise.resolve(scout.setup()) : (0, global_1.getOrCreateActiveGlobalScoutInstance)())
             .then(scout => scout.instrumentSync(op, cb));
     },
     // API
@@ -67,7 +70,7 @@ const API = {
         WebTransaction: {
             run(op, cb, scout) {
                 const name = `Controller/${op}`;
-                return (scout ? Promise.resolve(scout.setup()) : global_1.getOrCreateActiveGlobalScoutInstance())
+                return (scout ? Promise.resolve(scout.setup()) : (0, global_1.getOrCreateActiveGlobalScoutInstance)())
                     .then(scout => scout.transaction(name, (finishRequest, other) => {
                     return scout.instrument(name, (finishSpan, info) => {
                         return cb(finishRequest, info);
@@ -76,7 +79,7 @@ const API = {
             },
             runSync(op, cb, scout) {
                 const name = `Controller/${op}`;
-                scout = scout || global_1.getActiveGlobalScoutInstance() || undefined;
+                scout = scout || (0, global_1.getActiveGlobalScoutInstance)() || undefined;
                 if (!scout) {
                     return;
                 }
@@ -88,7 +91,7 @@ const API = {
         BackgroundTransaction: {
             run(op, cb, scout) {
                 const name = `Job/${op}`;
-                return (scout ? Promise.resolve(scout.setup()) : global_1.getOrCreateActiveGlobalScoutInstance())
+                return (scout ? Promise.resolve(scout.setup()) : (0, global_1.getOrCreateActiveGlobalScoutInstance)())
                     .then(scout => scout.transaction(name, (finishRequest, other) => {
                     return scout.instrument(name, (finishSpan, info) => {
                         return cb(finishRequest, info);
@@ -97,7 +100,7 @@ const API = {
             },
             runSync(op, cb, scout) {
                 const name = `Job/${op}`;
-                scout = scout || global_1.getActiveGlobalScoutInstance() || undefined;
+                scout = scout || (0, global_1.getActiveGlobalScoutInstance)() || undefined;
                 if (!scout) {
                     return;
                 }
@@ -107,22 +110,22 @@ const API = {
             },
         },
         instrument(op, cb, scout) {
-            return (scout ? Promise.resolve(scout.setup()) : global_1.getOrCreateActiveGlobalScoutInstance())
+            return (scout ? Promise.resolve(scout.setup()) : (0, global_1.getOrCreateActiveGlobalScoutInstance)())
                 .then(scout => scout.instrument(op, (finishSpan, info) => {
                 return cb(finishSpan, info);
             }));
         },
         instrumentSync(operation, fn, scout) {
-            return (scout ? Promise.resolve(scout.setup()) : global_1.getOrCreateActiveGlobalScoutInstance())
+            return (scout ? Promise.resolve(scout.setup()) : (0, global_1.getOrCreateActiveGlobalScoutInstance)())
                 .then(scout => scout.instrumentSync(operation, fn));
         },
         get Config() {
-            const scout = global_1.getActiveGlobalScoutInstance();
+            const scout = (0, global_1.getActiveGlobalScoutInstance)();
             return scout ? scout.getConfig() : undefined;
         },
         Context: {
             add(name, value, scout) {
-                return (scout ? Promise.resolve(scout.setup()) : global_1.getOrCreateActiveGlobalScoutInstance())
+                return (scout ? Promise.resolve(scout.setup()) : (0, global_1.getOrCreateActiveGlobalScoutInstance)())
                     .then(scout => {
                     const req = scout.getCurrentRequest();
                     if (!req) {
@@ -132,7 +135,7 @@ const API = {
                 });
             },
             addSync(name, value, scout) {
-                scout = scout || global_1.getActiveGlobalScoutInstance() || undefined;
+                scout = scout || (0, global_1.getActiveGlobalScoutInstance)() || undefined;
                 if (!scout) {
                     return;
                 }
@@ -144,7 +147,7 @@ const API = {
             },
         },
         ignoreTransaction(scout) {
-            return (scout ? Promise.resolve(scout.setup()) : global_1.getOrCreateActiveGlobalScoutInstance())
+            return (scout ? Promise.resolve(scout.setup()) : (0, global_1.getOrCreateActiveGlobalScoutInstance)())
                 .then(scout => {
                 const req = scout.getCurrentRequest();
                 if (!req) {
@@ -154,7 +157,7 @@ const API = {
             });
         },
         ignoreTransactionSync(scout) {
-            scout = scout || global_1.getActiveGlobalScoutInstance() || undefined;
+            scout = scout || (0, global_1.getActiveGlobalScoutInstance)() || undefined;
             if (!scout) {
                 return;
             }

--- a/dist/lib/job-queue-time.d.ts
+++ b/dist/lib/job-queue-time.d.ts
@@ -1,0 +1,20 @@
+import ScoutSpan from "./scout/span";
+/**
+ * Tag a background job span with how long it waited in the queue before
+ * being picked up. Scout displays this as "Queue Latency" in the background
+ * jobs UI.
+ *
+ * `enqueuedAt` can be any of:
+ *   - a `Date` object
+ *   - milliseconds since epoch (integer > 1e12)
+ *   - seconds since epoch (float < 1e12)
+ *   - nanoseconds since epoch (integer > 1e18)
+ *
+ * Example (BullMQ):
+ *   const job = await queue.getJob(jobId);
+ *   trackJobQueueTime(span, job.timestamp); // BullMQ timestamps are ms
+ *
+ * Example (manual):
+ *   trackJobQueueTime(span, new Date(payload.enqueuedAt));
+ */
+export declare function trackJobQueueTime(span: ScoutSpan, enqueuedAt: Date | number): void;

--- a/dist/lib/job-queue-time.js
+++ b/dist/lib/job-queue-time.js
@@ -1,0 +1,44 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.trackJobQueueTime = void 0;
+const enum_1 = require("./types/enum");
+/**
+ * Tag a background job span with how long it waited in the queue before
+ * being picked up. Scout displays this as "Queue Latency" in the background
+ * jobs UI.
+ *
+ * `enqueuedAt` can be any of:
+ *   - a `Date` object
+ *   - milliseconds since epoch (integer > 1e12)
+ *   - seconds since epoch (float < 1e12)
+ *   - nanoseconds since epoch (integer > 1e18)
+ *
+ * Example (BullMQ):
+ *   const job = await queue.getJob(jobId);
+ *   trackJobQueueTime(span, job.timestamp); // BullMQ timestamps are ms
+ *
+ * Example (manual):
+ *   trackJobQueueTime(span, new Date(payload.enqueuedAt));
+ */
+function trackJobQueueTime(span, enqueuedAt) {
+    const nowNs = Date.now() * 1e6;
+    const startNs = toNanoseconds(enqueuedAt);
+    const queueTimeNs = Math.max(0, Math.round(nowNs - startNs));
+    span.addContextSync(enum_1.ScoutContextName.JobQueueTimeNS, queueTimeNs);
+}
+exports.trackJobQueueTime = trackJobQueueTime;
+function toNanoseconds(value) {
+    if (value instanceof Date) {
+        return value.getTime() * 1e6;
+    }
+    // nanoseconds  (> year 2001 in ns = 1e18)
+    if (value > 1e18) {
+        return value;
+    }
+    // milliseconds (> year 2001 in ms = 1e12)
+    if (value > 1e12) {
+        return value * 1e6;
+    }
+    // seconds (float or int)
+    return value * 1e9;
+}

--- a/dist/lib/types/enum.d.ts
+++ b/dist/lib/types/enum.d.ts
@@ -43,7 +43,8 @@ export declare enum AgentRequestType {
     V1StartSpan = "v1-start-span",
     V1StopSpan = "v1-stop-span",
     V1TagSpan = "v1-tag-span",
-    V1ApplicationEvent = "v1-application-event"
+    V1ApplicationEvent = "v1-application-event",
+    V1BatchCommand = "v1-batch-command"
 }
 export declare enum AgentResponseType {
     Unknown = "unknown",
@@ -56,6 +57,7 @@ export declare enum AgentResponseType {
     V1StopSpan = "v1-stop-span-response",
     V1TagSpan = "v1-tag-span-response",
     V1ApplicationEvent = "v1-application-event-response",
+    V1BatchCommand = "v1-batch-command-response",
     V1Failure = "v1-failure-response"
 }
 export declare function isLogLevel(lvl: string): lvl is LogLevel;
@@ -105,7 +107,9 @@ export declare enum ScoutContextName {
     Path = "path",
     Timeout = "timeout",
     IgnoreTransaction = "ignore_transaction",
-    QueueTimeNS = "scout.queue_time_ns"
+    QueueTimeNS = "scout.queue_time_ns",
+    JobQueueTimeNS = "scout.job_queue_time_ns",
+    Queue = "queue"
 }
 export declare enum ScoutSpanOperation {
     SQLQuery = "SQL/Query",

--- a/dist/lib/types/enum.js
+++ b/dist/lib/types/enum.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.ScoutSpanOperation = exports.ScoutContextName = exports.ScoutEvent = exports.PlatformTriple = exports.Platform = exports.Architecture = exports.ConfigSourceName = exports.parseLogLevel = exports.isLogLevel = exports.AgentResponseType = exports.AgentRequestType = exports.AgentEvent = exports.ApplicationEventType = exports.LogLevel = exports.AgentType = exports.URIReportingLevel = exports.APIVersion = void 0;
 var APIVersion;
 (function (APIVersion) {
     APIVersion["V1"] = "1.0";
@@ -53,6 +54,7 @@ var AgentRequestType;
     AgentRequestType["V1StopSpan"] = "v1-stop-span";
     AgentRequestType["V1TagSpan"] = "v1-tag-span";
     AgentRequestType["V1ApplicationEvent"] = "v1-application-event";
+    AgentRequestType["V1BatchCommand"] = "v1-batch-command";
 })(AgentRequestType = exports.AgentRequestType || (exports.AgentRequestType = {}));
 var AgentResponseType;
 (function (AgentResponseType) {
@@ -66,6 +68,7 @@ var AgentResponseType;
     AgentResponseType["V1StopSpan"] = "v1-stop-span-response";
     AgentResponseType["V1TagSpan"] = "v1-tag-span-response";
     AgentResponseType["V1ApplicationEvent"] = "v1-application-event-response";
+    AgentResponseType["V1BatchCommand"] = "v1-batch-command-response";
     AgentResponseType["V1Failure"] = "v1-failure-response";
 })(AgentResponseType = exports.AgentResponseType || (exports.AgentResponseType = {}));
 // Check if a given string is a valid log level
@@ -133,6 +136,8 @@ var ScoutContextName;
     ScoutContextName["Timeout"] = "timeout";
     ScoutContextName["IgnoreTransaction"] = "ignore_transaction";
     ScoutContextName["QueueTimeNS"] = "scout.queue_time_ns";
+    ScoutContextName["JobQueueTimeNS"] = "scout.job_queue_time_ns";
+    ScoutContextName["Queue"] = "queue";
 })(ScoutContextName = exports.ScoutContextName || (exports.ScoutContextName = {}));
 var ScoutSpanOperation;
 (function (ScoutSpanOperation) {

--- a/dist/test/integration/nest.int.js
+++ b/dist/test/integration/nest.int.js
@@ -97,7 +97,7 @@ ExtendedTestModule = tslib_1.__decorate([
 ], ExtendedTestModule);
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function buildConfig(mock, extra) {
-    return (0, types_1.buildScoutConfiguration)(Object.assign({ allowShutdown: true, monitor: true, coreAgentDownload: false, coreAgentLaunch: false, socketPath: mock.socketPath() }, extra));
+    return (0, types_1.buildScoutConfiguration)(Object.assign({ monitor: true, coreAgentDownload: false, coreAgentLaunch: false, socketPath: mock.socketPath() }, extra));
 }
 function nextRequestSent(scout) {
     return new Promise((resolve, reject) => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ import * as Errors from "./errors";
 import { scoutMiddleware as expressMiddleware, errorMiddleware } from "./express";
 import { nestMiddleware as nestMiddlewareImpl, nestErrorFilter as nestErrorFilterImpl } from "./nest";
 import { captureError } from "./error-monitor";
+import { trackJobQueueTime } from "./job-queue-time";
 
 import { Scout, ScoutRequest, DoneCallback, SpanCallback, RequestCallback } from "./scout";
 import { ScoutConfiguration, JSONValue, buildScoutConfiguration, consoleLogFn, buildWinstonLogFn } from "./types";
@@ -43,6 +44,9 @@ const API = {
 
     // Error monitoring
     captureError,
+
+    // Background jobs
+    trackJobQueueTime,
 
     // Logging
     consoleLogFn,

--- a/lib/job-queue-time.ts
+++ b/lib/job-queue-time.ts
@@ -1,0 +1,42 @@
+import { ScoutContextName } from "./types/enum";
+import ScoutSpan from "./scout/span";
+
+/**
+ * Tag a background job span with how long it waited in the queue before
+ * being picked up. Scout displays this as "Queue Latency" in the background
+ * jobs UI.
+ *
+ * `enqueuedAt` can be any of:
+ *   - a `Date` object
+ *   - milliseconds since epoch (integer > 1e12)
+ *   - seconds since epoch (float < 1e12)
+ *   - nanoseconds since epoch (integer > 1e18)
+ *
+ * Example (BullMQ):
+ *   const job = await queue.getJob(jobId);
+ *   trackJobQueueTime(span, job.timestamp); // BullMQ timestamps are ms
+ *
+ * Example (manual):
+ *   trackJobQueueTime(span, new Date(payload.enqueuedAt));
+ */
+export function trackJobQueueTime(
+    span: ScoutSpan,
+    enqueuedAt: Date | number,
+): void {
+    const nowNs = Date.now() * 1e6;
+    const startNs = toNanoseconds(enqueuedAt);
+    const queueTimeNs = Math.max(0, Math.round(nowNs - startNs));
+    span.addContextSync(ScoutContextName.JobQueueTimeNS, queueTimeNs);
+}
+
+function toNanoseconds(value: Date | number): number {
+    if (value instanceof Date) {
+        return value.getTime() * 1e6;
+    }
+    // nanoseconds  (> year 2001 in ns = 1e18)
+    if (value > 1e18) { return value; }
+    // milliseconds (> year 2001 in ms = 1e12)
+    if (value > 1e12) { return value * 1e6; }
+    // seconds (float or int)
+    return value * 1e9;
+}

--- a/lib/types/enum.ts
+++ b/lib/types/enum.ts
@@ -147,6 +147,8 @@ export enum ScoutContextName {
     Timeout = "timeout",
     IgnoreTransaction = "ignore_transaction",
     QueueTimeNS = "scout.queue_time_ns",
+    JobQueueTimeNS = "scout.job_queue_time_ns",
+    Queue = "queue",
 }
 
 export enum ScoutSpanOperation {

--- a/test/integration/nest.int.ts
+++ b/test/integration/nest.int.ts
@@ -60,7 +60,6 @@ class ExtendedTestModule {}
 
 function buildConfig(mock: MockAgent, extra?: object) {
     return buildScoutConfiguration({
-        allowShutdown: true,
         monitor: true,
         coreAgentDownload: false,
         coreAgentLaunch: false,


### PR DESCRIPTION
## Summary

- Adds `trackJobQueueTime(request, enqueuedAt)` helper that calculates queue latency from an enqueued-at timestamp and tags the span with `scout.job_queue_time_ns`
- Adds `ScoutContextName.JobQueueTimeNS` and `ScoutContextName.Queue` enum values
- Helper accepts Date, milliseconds, seconds, or nanoseconds (same normalization as Python agent)
- Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)