### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.1] - 2026-06-05
 
 ### Changed
-- Publish workflow now uses OIDC trusted publishing — no `NPM_TOKEN` secret required ([#337](https://github.com/scoutapp/scout_apm_node/pull/337))
-- Removed compiled `dist/` files from source control — generated at publish time ([#339](https://github.com/scoutapp/scout_apm_node/pull/339))
+- Publish workflow now uses OIDC trusted publishing ([#337](https://github.com/scoutapp/scout_apm_node/pull/337))
+- Removed compiled `dist/` files from source control ([#339](https://github.com/scoutapp/scout_apm_node/pull/339))
 
 ## [2.0.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-06-05
+
+### Changed
+- Publish workflow now uses OIDC trusted publishing — no `NPM_TOKEN` secret required ([#337](https://github.com/scoutapp/scout_apm_node/pull/337))
+- Removed compiled `dist/` files from source control — generated at publish time ([#339](https://github.com/scoutapp/scout_apm_node/pull/339))
+
 ## [2.0.0] - 2026-06-04
 
 ### Added
@@ -212,7 +218,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial implementation of NodeJS agent
 
-[Unreleased]: https://github.com/scoutapp/scout_apm_node/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/scoutapp/scout_apm_node/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/scoutapp/scout_apm_node/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/scoutapp/scout_apm_node/compare/v0.2.3...v2.0.0
 [0.2.3]: https://github.com/scoutapp/scout_apm_node/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/scoutapp/scout_apm_node/compare/v0.2.2-rc.1...v0.2.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scout_apm/scout-apm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Scout APM Node Agent",
   "main": "dist/lib/index.js",
   "repository": "git@github.com:scoutapp/scout_apm_node.git",
@@ -113,7 +113,6 @@
     "app-root-path": "^3.0.0",
     "tslib": "^2.8.1",
     "big-number": "^2.0.0",
-
     "cpu-percentage": "^1.0.3",
     "detect-libc": "1.0.3",
     "download": "7.1.0",


### PR DESCRIPTION
## Summary

- Bumps version to `2.0.1`
- Adds changelog entry for OIDC trusted publishing and dist cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)