### PR TITLE
feat(log-management): transaction ID, request context, and Context.add fix

### DIFF
--- a/lib/error-monitor.ts
+++ b/lib/error-monitor.ts
@@ -1,6 +1,7 @@
 import * as os from "os";
 import { ScoutConfiguration } from "./types";
 import { ErrorService } from "./error-service";
+import { getActiveGlobalScoutInstance } from "./global";
 
 let service: ErrorService | null = null;
 let ignoredExceptions: string[] = [];
@@ -97,6 +98,13 @@ export function captureError(
 
     if (isIgnored(err)) { return; }
 
+    const scout = getActiveGlobalScoutInstance();
+    const transactionId = scout?.getCurrentRequest()?.id ?? null;
+
+    const mergedContext = transactionId
+        ? { transaction_id: transactionId, ...(context || {}) }
+        : context || undefined;
+
     const hasLocation = opts && (opts.controller != null || opts.action != null || opts.module != null);
 
     service.enqueue({
@@ -113,7 +121,7 @@ export function captureError(
             controller: (opts && opts.controller) ?? null,
             action: (opts && opts.action) ?? null,
         } : null,
-        context: context || undefined,
+        context: mergedContext,
         host: (currentConfig.hostname as string) || os.hostname(),
         revision_sha: currentConfig.revisionSHA,
     });

--- a/lib/error-service.ts
+++ b/lib/error-service.ts
@@ -116,10 +116,19 @@ export class ErrorService {
             };
 
             const req = transport.request(options, (res) => {
+                if (this.config.logPayloadContent) {
+                    // tslint:disable-next-line no-console
+                    console.log(`[scout/error-payload] response ${res.statusCode} from ${parsedUrl.hostname}`);
+                }
                 res.resume();
             });
 
-            req.on("error", () => { /* swallow network errors */ });
+            req.on("error", (err) => {
+                if (this.config.logPayloadContent) {
+                    // tslint:disable-next-line no-console
+                    console.log(`[scout/error-payload] send error: ${err.message}`);
+                }
+            });
             req.write(compressed);
             req.end();
         });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -146,14 +146,13 @@ const API = {
         },
 
         Context: {
+            // Kept for backwards compatibility — the async signature was never necessary.
+            // addContextSync is a plain object property set; there is nothing to await.
+            // Delegating to addSync means context is on the request immediately, so log
+            // integrations that read tags synchronously (pino diagnostics_channel, etc.)
+            // see the values without requiring callers to switch to addSync.
             add(name: string, value: JSONValue, scout?: Scout): Promise<ScoutRequest | void> {
-                return (scout ? Promise.resolve(scout.setup()) : getOrCreateActiveGlobalScoutInstance())
-                    .then(scout => {
-                        const req = scout.getCurrentRequest();
-                        if (!req) { return; }
-
-                        return req.addContext(name, value);
-                    });
+                return Promise.resolve(this.addSync(name, value, scout));
             },
 
             addSync(name: string, value: JSONValue, scout?: Scout): ScoutRequest | undefined {

--- a/lib/log-management.ts
+++ b/lib/log-management.ts
@@ -1,6 +1,7 @@
 // Orchestrates Scout log management: initializes the buffer, wires up integrations.
 // Called from global.ts after Scout configuration is resolved.
 import { ScoutConfiguration } from "./types";
+import { parseLogLevel } from "./types/enum";
 import { ScoutLogBuffer } from "./logs/buffer";
 import { setupPinoIntegration } from "./logs/integrations/pino";
 import { setupConsoleIntegration } from "./logs/integrations/console";
@@ -25,10 +26,12 @@ export function setupLogManagement(
         agentVersion = require("../package.json").version || "";
     } catch { /* ignore */ }
 
+    const logLevel = parseLogLevel(process.env.SCOUT_LOG_LEVEL || (config.logLevel as any) || "warn");
+
     if (logBuffer) {
-        logBuffer.updateOpts({ endpointHttp, ingestKey, serviceName, agentVersion });
+        logBuffer.updateOpts({ endpointHttp, ingestKey, serviceName, agentVersion, logLevel });
     } else {
-        logBuffer = new ScoutLogBuffer({ endpointHttp, ingestKey, serviceName, agentVersion });
+        logBuffer = new ScoutLogBuffer({ endpointHttp, ingestKey, serviceName, agentVersion, logLevel });
     }
 
     // Wire winston integration (RITM hook already set up; needs the buffer reference)

--- a/lib/logs/integrations/console.ts
+++ b/lib/logs/integrations/console.ts
@@ -37,10 +37,11 @@ export function setupConsoleIntegration(
         (console as any)[method] = (...args: any[]) => {
             original(...args);
             if (!meetsMinLevel(level, captureLevel)) { return; }
+            if (args.length > 0 && typeof args[0] === "string" && args[0].includes("[scout/")) { return; }
 
             const now = nowNanos();
             const scout = getScout();
-            const requestId: string | null = scout?.getCurrentSpan?.()?.id ?? null;
+            const requestId: string | null = scout?.getCurrentRequest?.()?.id ?? null;
 
             logBuffer.append({
                 timeUnixNano: now,
@@ -54,7 +55,7 @@ export function setupConsoleIntegration(
                 },
                 attributes: [
                     { key: "logger.name", value: { stringValue: "console" } },
-                    ...(requestId ? [{ key: "scout.request_id", value: { stringValue: requestId } }] : []),
+                    ...(requestId ? [{ key: "scout_transaction_id", value: { stringValue: requestId } }] : []),
                 ],
             });
         };

--- a/lib/logs/integrations/console.ts
+++ b/lib/logs/integrations/console.ts
@@ -2,7 +2,7 @@
 // Patches global console methods to forward log entries to the Scout log buffer.
 // Active when logs_monitor=true and logs_capture_console=true (default).
 import { ScoutLogBuffer } from "../buffer";
-import { levelToSeverityNumber, levelToSeverityText, nowNanos } from "../otlp";
+import { levelToSeverityNumber, levelToSeverityText, nowNanos, getContextAttributes } from "../otlp";
 
 const CONSOLE_LEVELS: Array<[keyof Console, string]> = [
     ["log",   "info"],
@@ -41,7 +41,8 @@ export function setupConsoleIntegration(
 
             const now = nowNanos();
             const scout = getScout();
-            const requestId: string | null = scout?.getCurrentRequest?.()?.id ?? null;
+            const request = scout?.getCurrentRequest?.() ?? null;
+            const requestId: string | null = request?.id ?? null;
 
             logBuffer.append({
                 timeUnixNano: now,
@@ -56,6 +57,7 @@ export function setupConsoleIntegration(
                 attributes: [
                     { key: "logger.name", value: { stringValue: "console" } },
                     ...(requestId ? [{ key: "scout_transaction_id", value: { stringValue: requestId } }] : []),
+                    ...getContextAttributes(request),
                 ],
             });
         };

--- a/lib/logs/integrations/pino.ts
+++ b/lib/logs/integrations/pino.ts
@@ -57,8 +57,7 @@ export function setupPinoIntegration(
 
         const now = nowNanos();
         const scout = getScout?.();
-        const request = scout?.getCurrentSpan?.() ?? null;
-        const requestId = request?.id ?? null;
+        const requestId = scout?.getCurrentRequest?.()?.id ?? null;
 
         buffer.append({
             timeUnixNano: now,
@@ -68,7 +67,7 @@ export function setupPinoIntegration(
             body: { stringValue: String(parsed.msg ?? "") },
             attributes: [
                 { key: "logger.name", value: { stringValue: "pino" } },
-                ...(requestId ? [{ key: "scout.request_id", value: { stringValue: requestId } }] : []),
+                ...(requestId ? [{ key: "scout_transaction_id", value: { stringValue: requestId } }] : []),
             ],
         });
     });

--- a/lib/logs/integrations/pino.ts
+++ b/lib/logs/integrations/pino.ts
@@ -8,7 +8,7 @@
 // Requires: pino >=v8.0.0, Node >=18.19.0 or >=20.6.0 (diagnostics_channel tracing channels).
 import * as diagnosticsChannel from "node:diagnostics_channel";
 import { ScoutLogBuffer } from "../buffer";
-import { levelToSeverityNumber, levelToSeverityText, nowNanos } from "../otlp";
+import { levelToSeverityNumber, levelToSeverityText, nowNanos, getContextAttributes } from "../otlp";
 
 type LevelMapping = { labels: Record<number, string> };
 type PinoInstance = { levels?: LevelMapping };
@@ -57,7 +57,8 @@ export function setupPinoIntegration(
 
         const now = nowNanos();
         const scout = getScout?.();
-        const requestId = scout?.getCurrentRequest?.()?.id ?? null;
+        const request = scout?.getCurrentRequest?.() ?? null;
+        const requestId = request?.id ?? null;
 
         buffer.append({
             timeUnixNano: now,
@@ -68,6 +69,7 @@ export function setupPinoIntegration(
             attributes: [
                 { key: "logger.name", value: { stringValue: "pino" } },
                 ...(requestId ? [{ key: "scout_transaction_id", value: { stringValue: requestId } }] : []),
+                ...getContextAttributes(request),
             ],
         });
     });

--- a/lib/logs/integrations/winston.ts
+++ b/lib/logs/integrations/winston.ts
@@ -51,7 +51,7 @@ function buildTransportClass(
 
             const now = nowNanos();
             const scout = getScout();
-            const requestId: string | null = scout?.getCurrentSpan?.()?.id ?? null;
+            const requestId: string | null = scout?.getCurrentRequest?.()?.id ?? null;
 
             // Collect extra fields (excluding message and level) as attributes
             const skip = new Set(["message", "level", "timestamp", "service", "splat"]);
@@ -70,7 +70,7 @@ function buildTransportClass(
                 body: { stringValue: typeof info.message === "string" ? info.message : JSON.stringify(info.message) },
                 attributes: [
                     { key: "logger.name", value: { stringValue: "winston" } },
-                    ...(requestId ? [{ key: "scout.request_id", value: { stringValue: requestId } }] : []),
+                    ...(requestId ? [{ key: "scout_transaction_id", value: { stringValue: requestId } }] : []),
                     ...extras,
                 ],
             });

--- a/lib/logs/integrations/winston.ts
+++ b/lib/logs/integrations/winston.ts
@@ -10,7 +10,7 @@
 //   https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-winston
 import { RequireIntegration, getIntegrationSymbol } from "../../types/integrations";
 import { ScoutLogBuffer } from "../buffer";
-import { levelToSeverityNumber, levelToSeverityText, nowNanos } from "../otlp";
+import { levelToSeverityNumber, levelToSeverityText, nowNanos, getContextAttributes } from "../otlp";
 
 const LEVEL_ORDER = ["trace", "debug", "info", "warn", "error", "fatal"];
 
@@ -51,7 +51,8 @@ function buildTransportClass(
 
             const now = nowNanos();
             const scout = getScout();
-            const requestId: string | null = scout?.getCurrentRequest?.()?.id ?? null;
+            const request = scout?.getCurrentRequest?.() ?? null;
+            const requestId: string | null = request?.id ?? null;
 
             // Collect extra fields (excluding message and level) as attributes
             const skip = new Set(["message", "level", "timestamp", "service", "splat"]);
@@ -71,6 +72,7 @@ function buildTransportClass(
                 attributes: [
                     { key: "logger.name", value: { stringValue: "winston" } },
                     ...(requestId ? [{ key: "scout_transaction_id", value: { stringValue: requestId } }] : []),
+                    ...getContextAttributes(request),
                     ...extras,
                 ],
             });

--- a/lib/logs/otlp.ts
+++ b/lib/logs/otlp.ts
@@ -32,6 +32,34 @@ export interface OtlpShipOptions {
     logLevel?: LogLevel;
 }
 
+// Scout-internal context keys — not forwarded to OTLP log attributes.
+const INTERNAL_CONTEXT_KEYS = new Set([
+    "stack", "db.statement", "error", "name", "url", "path", "timeout",
+    "ignore_transaction", "scout.queue_time_ns", "scout.job_queue_time_ns",
+    "queue", "task_id", "priority", "db.operation", "db.model",
+]);
+
+export function getContextAttributes(request: any): OtlpKeyValue[] {
+    if (!request || typeof request.getTags !== "function") { return []; }
+    const tags: Array<{ name: string; value: any }> = request.getTags();
+    const attrs: OtlpKeyValue[] = [];
+    for (const tag of tags) {
+        if (INTERNAL_CONTEXT_KEYS.has(tag.name) || tag.name.startsWith("scout.")) { continue; }
+        let value: OtlpKeyValue["value"];
+        if (typeof tag.value === "boolean") {
+            value = { boolValue: tag.value };
+        } else if (typeof tag.value === "number" && Number.isInteger(tag.value)) {
+            value = { intValue: tag.value };
+        } else if (typeof tag.value === "string") {
+            value = { stringValue: tag.value };
+        } else {
+            value = { stringValue: JSON.stringify(tag.value) };
+        }
+        attrs.push({ key: tag.name, value });
+    }
+    return attrs;
+}
+
 // Maps severity level names to OTel SeverityNumber (per OTel Logs Data Model spec).
 const SEVERITY_NUMBER: Record<string, number> = {
     trace: 1, debug: 5, info: 9, warn: 13, warning: 13, error: 17, fatal: 21,

--- a/lib/logs/otlp.ts
+++ b/lib/logs/otlp.ts
@@ -3,6 +3,10 @@
 import * as https from "https";
 import * as http from "http";
 import * as url from "url";
+import * as fs from "fs";
+import * as zlib from "zlib";
+import { consoleLogFn, isIgnoredLogMessage } from "../types/util";
+import { LogLevel } from "../types/enum";
 
 export interface OtlpKeyValue {
     key: string;
@@ -10,8 +14,8 @@ export interface OtlpKeyValue {
 }
 
 export interface OtlpLogRecord {
-    timeUnixNano: string;
-    observedTimeUnixNano: string;
+    timeUnixNano: number;
+    observedTimeUnixNano: number;
     severityText: string;
     severityNumber: number;
     body: { stringValue: string };
@@ -25,6 +29,7 @@ export interface OtlpShipOptions {
     ingestKey: string;
     serviceName: string;
     agentVersion: string;
+    logLevel?: LogLevel;
 }
 
 // Maps severity level names to OTel SeverityNumber (per OTel Logs Data Model spec).
@@ -45,13 +50,11 @@ export function levelToSeverityText(level: string): string {
     return map[l] ?? "INFO";
 }
 
-// Returns nanoseconds-since-epoch as a decimal string without BigInt literals
-// (which require ES2020 and would break the ES6 build target).
-export function nowNanos(): string {
+// Returns nanoseconds-since-epoch as a number.
+// Precision loss beyond 2^53 (~9ms in 2026) is acceptable for log timestamps.
+export function nowNanos(): number {
     const ms = Date.now();
-    const sec = Math.floor(ms / 1000);
-    const nsRem = (ms % 1000) * 1000000;
-    return String(sec) + String(nsRem).padStart(9, "0");
+    return ms * 1000000;
 }
 
 export function buildExportRequest(
@@ -76,30 +79,71 @@ export function buildExportRequest(
     };
 }
 
+const GZIP_THRESHOLD_BYTES = 1024;
+
 export function shipLogs(records: OtlpLogRecord[], opts: OtlpShipOptions): void {
     if (records.length === 0) { return; }
 
     const payload = JSON.stringify(buildExportRequest(records, opts));
+    const payloadBuf = Buffer.from(payload, "utf8");
     const parsed = url.parse(opts.endpointHttp);
     const isHttps = parsed.protocol === "https:";
     const lib = isHttps ? https : http;
     const port = parsed.port ? parseInt(parsed.port, 10) : (isHttps ? 443 : 80);
 
-    const req = lib.request({
-        hostname: parsed.hostname,
-        port,
-        path: parsed.path || "/v1/logs",
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "Content-Length": Buffer.byteLength(payload),
-            "x-telemetry-key": opts.ingestKey,
-        },
-    }, (res) => {
-        res.resume(); // drain response
-    });
+    const configLevel = opts.logLevel ?? LogLevel.Warn;
+    const debugEnabled = !isIgnoredLogMessage(configLevel, LogLevel.Debug);
+    const ts = new Date().toISOString();
 
-    req.on("error", () => { /* fire-and-forget; buffer will retry next flush */ });
-    req.write(payload);
-    req.end();
+    const shouldGzip = payloadBuf.length > GZIP_THRESHOLD_BYTES;
+
+    const sendRequest = (body: Buffer) => {
+        const headers: Record<string, string | number> = {
+            "Content-Type": "application/json",
+            "Content-Length": body.length,
+            "x-telemetryhub-key": opts.ingestKey,
+        };
+        if (shouldGzip) { headers["Content-Encoding"] = "gzip"; }
+
+        if (debugEnabled) {
+            consoleLogFn(`[scout/logs] ${ts} sending ${records.length} record(s) to ${opts.endpointHttp} (${body.length} bytes${shouldGzip ? ", gzipped" : ""})`, LogLevel.Debug);
+            try {
+                const capture = JSON.stringify({ ts, endpoint: opts.endpointHttp, headers, payload: JSON.parse(payload) }, null, 2);
+                fs.writeFileSync("/scout_debug/otlp_payload.json", capture, "utf8");
+            } catch { /* ignore write errors */ }
+        }
+
+        const req = lib.request({
+            hostname: parsed.hostname,
+            port,
+            path: parsed.path || "/v1/logs",
+            method: "POST",
+            headers,
+        }, (res) => {
+            let resBody = "";
+            res.on("data", (chunk) => { resBody += chunk; });
+            res.on("end", () => {
+                if (debugEnabled) { consoleLogFn(`[scout/logs] ${new Date().toISOString()} response ${res.statusCode} from ${opts.endpointHttp}${resBody ? ": " + resBody.slice(0, 200) : ""}`, LogLevel.Debug); }
+            });
+        });
+
+        req.on("error", (err) => {
+            consoleLogFn(`[scout/logs] ${new Date().toISOString()} error shipping to ${opts.endpointHttp}: ${err.message} (${(err as any).code})`, LogLevel.Warn);
+        });
+        req.write(body);
+        req.end();
+    };
+
+    if (shouldGzip) {
+        zlib.gzip(payloadBuf, (err, compressed) => {
+            if (err) {
+                consoleLogFn(`[scout/logs] gzip error, sending uncompressed: ${err.message}`, LogLevel.Warn);
+                sendRequest(payloadBuf);
+            } else {
+                sendRequest(compressed);
+            }
+        });
+    } else {
+        sendRequest(payloadBuf);
+    }
 }


### PR DESCRIPTION
## Summary

Three improvements built on the log management core:

### 1. Transaction ID + error auto-injection (`47610d5`)
- Renamed OTLP log attribute `scout.request_id` → `scout_transaction_id` across pino, winston, and console integrations
- `captureError` now auto-resolves the active Scout request ID and injects it as `transaction_id` in error context (no manual wiring needed)
- `ErrorService` logs HTTP response status and send errors when `logPayloadContent` is enabled
- `shipLogs`: gzip payloads >1KB, debug logging for send/response, fixed header to `x-telemetryhub-key`

### 2. Request context as OTLP attributes (`1538da8`)
- Added `getContextAttributes()` to `otlp.ts` — reads the active Scout request's tags (set via `api.Context.add`) and emits them as log record attributes
- Filters out Scout-internal keys (`db.statement`, `ignore_transaction`, etc.)
- All three integrations now include user context alongside `scout_transaction_id` on every captured log record

### 3. Make `Context.add` synchronous (`d5a9386`)
- The underlying operation is a plain object property set — there was never anything to await
- Previously routed through `getOrCreateActiveGlobalScoutInstance()` so context landed on the next microtask tick, too late for pino's synchronous `diagnostics_channel` callback
- Now delegates to `addSync` and wraps in `Promise.resolve()` — existing `await` call sites continue to work

*Stacked on `feat/log-management`.*

## Test plan
- [ ] Hit `/log/structured` on pino and winston apps; confirm `userId`, `action`, `region` appear as OTLP attributes in `debug/otlp_payload.json`
- [ ] Confirm `[scout/error-payload] response 202` appears in container logs
- [ ] Confirm `transaction_id` matches `scout_transaction_id` between error payload and log record

🤖 Generated with [Claude Code](https://claude.com/claude-code)