### PR TITLE
feat: attach transaction entrypoint to log records; wire log_payload_…

### DIFF
--- a/lib/log-management.ts
+++ b/lib/log-management.ts
@@ -27,11 +27,12 @@ export function setupLogManagement(
     } catch { /* ignore */ }
 
     const logLevel = parseLogLevel(process.env.SCOUT_LOG_LEVEL || (config.logLevel as any) || "warn");
+    const logPayloadContent = config.logPayloadContent === true;
 
     if (logBuffer) {
-        logBuffer.updateOpts({ endpointHttp, ingestKey, serviceName, agentVersion, logLevel });
+        logBuffer.updateOpts({ endpointHttp, ingestKey, serviceName, agentVersion, logLevel, logPayloadContent });
     } else {
-        logBuffer = new ScoutLogBuffer({ endpointHttp, ingestKey, serviceName, agentVersion, logLevel });
+        logBuffer = new ScoutLogBuffer({ endpointHttp, ingestKey, serviceName, agentVersion, logLevel, logPayloadContent });
     }
 
     // Wire winston integration (RITM hook already set up; needs the buffer reference)

--- a/lib/logs/integrations/console.ts
+++ b/lib/logs/integrations/console.ts
@@ -2,7 +2,7 @@
 // Patches global console methods to forward log entries to the Scout log buffer.
 // Active when logs_monitor=true and logs_capture_console=true (default).
 import { ScoutLogBuffer } from "../buffer";
-import { levelToSeverityNumber, levelToSeverityText, nowNanos, getContextAttributes } from "../otlp";
+import { levelToSeverityNumber, levelToSeverityText, nowNanos, getContextAttributes, getEntrypointAttributes } from "../otlp";
 
 const CONSOLE_LEVELS: Array<[keyof Console, string]> = [
     ["log",   "info"],
@@ -57,6 +57,7 @@ export function setupConsoleIntegration(
                 attributes: [
                     { key: "logger.name", value: { stringValue: "console" } },
                     ...(requestId ? [{ key: "scout_transaction_id", value: { stringValue: requestId } }] : []),
+                    ...getEntrypointAttributes(request),
                     ...getContextAttributes(request),
                 ],
             });

--- a/lib/logs/integrations/pino.ts
+++ b/lib/logs/integrations/pino.ts
@@ -8,7 +8,7 @@
 // Requires: pino >=v8.0.0, Node >=18.19.0 or >=20.6.0 (diagnostics_channel tracing channels).
 import * as diagnosticsChannel from "node:diagnostics_channel";
 import { ScoutLogBuffer } from "../buffer";
-import { levelToSeverityNumber, levelToSeverityText, nowNanos, getContextAttributes } from "../otlp";
+import { levelToSeverityNumber, levelToSeverityText, nowNanos, getContextAttributes, getEntrypointAttributes } from "../otlp";
 
 type LevelMapping = { labels: Record<number, string> };
 type PinoInstance = { levels?: LevelMapping };
@@ -69,6 +69,7 @@ export function setupPinoIntegration(
             attributes: [
                 { key: "logger.name", value: { stringValue: "pino" } },
                 ...(requestId ? [{ key: "scout_transaction_id", value: { stringValue: requestId } }] : []),
+                ...getEntrypointAttributes(request),
                 ...getContextAttributes(request),
             ],
         });

--- a/lib/logs/integrations/winston.ts
+++ b/lib/logs/integrations/winston.ts
@@ -10,7 +10,7 @@
 //   https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-winston
 import { RequireIntegration, getIntegrationSymbol } from "../../types/integrations";
 import { ScoutLogBuffer } from "../buffer";
-import { levelToSeverityNumber, levelToSeverityText, nowNanos, getContextAttributes } from "../otlp";
+import { levelToSeverityNumber, levelToSeverityText, nowNanos, getContextAttributes, getEntrypointAttributes } from "../otlp";
 
 const LEVEL_ORDER = ["trace", "debug", "info", "warn", "error", "fatal"];
 
@@ -72,6 +72,7 @@ function buildTransportClass(
                 attributes: [
                     { key: "logger.name", value: { stringValue: "winston" } },
                     ...(requestId ? [{ key: "scout_transaction_id", value: { stringValue: requestId } }] : []),
+                    ...getEntrypointAttributes(request),
                     ...getContextAttributes(request),
                     ...extras,
                 ],

--- a/lib/logs/otlp.ts
+++ b/lib/logs/otlp.ts
@@ -3,7 +3,6 @@
 import * as https from "https";
 import * as http from "http";
 import * as url from "url";
-import * as fs from "fs";
 import * as zlib from "zlib";
 import { consoleLogFn, isIgnoredLogMessage } from "../types/util";
 import { LogLevel } from "../types/enum";
@@ -30,6 +29,7 @@ export interface OtlpShipOptions {
     serviceName: string;
     agentVersion: string;
     logLevel?: LogLevel;
+    logPayloadContent?: boolean;
 }
 
 // Scout-internal context keys — not forwarded to OTLP log attributes.
@@ -38,6 +38,37 @@ const INTERNAL_CONTEXT_KEYS = new Set([
     "ignore_transaction", "scout.queue_time_ns", "scout.job_queue_time_ns",
     "queue", "task_id", "priority", "db.operation", "db.model",
 ]);
+
+// Derives the transaction entrypoint from the current request's span tree, mirroring the
+// ruby logging agent's controller_entrypoint/job_entrypoint attributes. The value matches
+// the transaction name shown for metrics (e.g. "Controller/GET /products", "Job/send-email").
+export function getEntrypointAttributes(request: any): OtlpKeyValue[] {
+    if (!request || typeof request.getChildSpansSync !== "function") { return []; }
+
+    // Breadth-first search: entrypoint spans are top-level, but tolerate nesting
+    const queue: any[] = request.getChildSpansSync();
+    while (queue.length > 0) {
+        const span = queue.shift();
+        const op = span?.operation;
+        if (typeof op === "string") {
+            if (op.startsWith("Controller/")) {
+                return [{ key: "controller_entrypoint", value: { stringValue: op } }];
+            }
+            if (op.startsWith("Job/")) {
+                const attrs: OtlpKeyValue[] = [{ key: "job_entrypoint", value: { stringValue: op } }];
+                const jobQueue = typeof span.getContextValue === "function" ? span.getContextValue("queue") : undefined;
+                if (typeof jobQueue === "string" && jobQueue.length > 0) {
+                    attrs.push({ key: "job_queue", value: { stringValue: jobQueue } });
+                }
+                return attrs;
+            }
+        }
+        if (typeof span?.getChildSpansSync === "function") {
+            queue.push(...span.getChildSpansSync());
+        }
+    }
+    return [];
+}
 
 export function getContextAttributes(request: any): OtlpKeyValue[] {
     if (!request || typeof request.getTags !== "function") { return []; }
@@ -135,10 +166,11 @@ export function shipLogs(records: OtlpLogRecord[], opts: OtlpShipOptions): void 
 
         if (debugEnabled) {
             consoleLogFn(`[scout/logs] ${ts} sending ${records.length} record(s) to ${opts.endpointHttp} (${body.length} bytes${shouldGzip ? ", gzipped" : ""})`, LogLevel.Debug);
-            try {
-                const capture = JSON.stringify({ ts, endpoint: opts.endpointHttp, headers, payload: JSON.parse(payload) }, null, 2);
-                fs.writeFileSync("/scout_debug/otlp_payload.json", capture, "utf8");
-            } catch { /* ignore write errors */ }
+        }
+
+        // The "[scout/" prefix also prevents the console integration from re-capturing this line
+        if (opts.logPayloadContent) {
+            consoleLogFn(`[scout/logs] ${ts} payload for ${opts.endpointHttp}: ${payload}`, LogLevel.Info);
         }
 
         const req = lib.request({


### PR DESCRIPTION
Log records now carry controller_entrypoint or job_entrypoint/job_queue attributes derived from the current request's span tree, mirroring the ruby logging agent's formatter so the log UI shows the endpoint location instead of default/default.

Logs now dumps the OTLP payload to stdout when log_payload_content is enabled, replacing the debug-only /scout_debug file write.