### PR TITLE
Sync yarn.lock self-reference to 2.1.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -305,7 +305,7 @@
   integrity sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==
 
 "@scout_apm/scout-apm@file:.":
-  version "2.1.0"
+  version "2.1.1"
   dependencies:
     "@types/ejs" "^3.0.0"
     "@types/fs-extra" "5.0.5"


### PR DESCRIPTION
Updates the `@scout_apm/scout-apm@file:.` self-reference in `yarn.lock` from `2.1.0` to `2.1.1` so it stays in sync with the version bump in #376.

This keeps `yarn install --frozen-lockfile` — used by the release/publish workflow (`publish.yml`) — consistent with `package.json`.

Split out from the release PR (#376) to keep the version bump matching the file set of previous bump PRs (#370, #345, #342), which only touch `package.json` + `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)