### PR TITLE
Bump version to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-08-27
+
+### Security
+- Removed the `download` dependency and replaced core-agent downloading/extraction with Node's built-in `https`/`zlib` plus `tar-stream`, eliminating the vulnerable `decompress`, `got`, and `http-cache-semantics` transitive dependencies. Extraction now guards against path traversal ("zip slip"). ([#374](https://github.com/scoutapp/scout_apm_node/pull/374))
+- Moved the test-only `tmp` dependency to `devDependencies` and bumped it to `0.2.7`, removing it from production installs. ([#374](https://github.com/scoutapp/scout_apm_node/pull/374))
+
 ## [2.1.0] - 2026-07-21
 
 ### Added
@@ -243,7 +249,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial implementation of NodeJS agent
 
-[Unreleased]: https://github.com/scoutapp/scout_apm_node/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/scoutapp/scout_apm_node/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/scoutapp/scout_apm_node/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/scoutapp/scout_apm_node/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/scoutapp/scout_apm_node/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/scoutapp/scout_apm_node/compare/v2.0.0...v2.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scout_apm/scout-apm",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Scout APM Node Agent",
   "main": "dist/lib/index.js",
   "repository": "git@github.com:scoutapp/scout_apm_node.git",


### PR DESCRIPTION
Patch release **2.1.1**. Bumps the version in `package.json` and adds the corresponding `CHANGELOG.md` entry — matching the file set of previous bump PRs (#370, #345, #342).

### Security
- Removed the `download` dependency; core-agent download/extraction now uses Node's built-in `https`/`zlib` plus `tar-stream`, eliminating the vulnerable `decompress`, `got`, and `http-cache-semantics` transitive dependencies, and adding path-traversal ("zip slip") protection. (#374)
- Moved the test-only `tmp` dependency to `devDependencies` (bumped to `0.2.7`), removing it from production installs. (#374)

### Stacking / merge order
This is stacked on the yarn.lock sync (#375), which is stacked on the fix (#374):

1. #374 — remove `download` dependency
2. #375 — sync `yarn.lock` self-reference to 2.1.1
3. #376 — this bump

Merge #374 → #375 → #376 into `master` in order (GitHub will retarget each to `master` as its base merges). Then tag `v2.1.1` on `master` to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)